### PR TITLE
Adopt CoreEvents lifecycle notifications

### DIFF
--- a/ecs/systems/condition_system.py
+++ b/ecs/systems/condition_system.py
@@ -25,7 +25,7 @@ from ecs.components.health import HealthComponent
 from ecs.components.initiative import InitiativeComponent
 from ecs.components.willpower import WillpowerComponent
 from ecs.ecs_manager import ECSManager
-from interface.event_constants import CoreEvents
+from interface.event_constants import CoreEvents, LEGACY_ALIAS_FIELD
 from utils.condition_utils import (
     WEAKENED_PHYSICAL,
     WEAKENED_MENTAL_SOCIAL,
@@ -140,11 +140,11 @@ class ConditionSystem:
         bus.subscribe(CoreEvents.TURN_START, self._on_turn_started)
         self._subscribe_legacy_alias(CoreEvents.TURN_START, self._on_turn_started_legacy)
 
-    def _subscribe_legacy_alias(self, canonical_event: str, handler: Callable[..., Any]) -> None:
+    def _subscribe_legacy_alias(self, event_name: str, handler: Callable[..., Any]) -> None:
         if not self.event_bus:
             return
-        legacy_name = LEGACY_EVENT_ALIASES.get(canonical_event)
-        if legacy_name and legacy_name != canonical_event:
+        legacy_name = LEGACY_EVENT_ALIASES.get(event_name)
+        if legacy_name and legacy_name != event_name:
             self.event_bus.subscribe(legacy_name, handler)
 
     # Registration helpers --------------------------------------------------
@@ -664,7 +664,7 @@ class ConditionSystem:
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if kwargs.get('_legacy_alias_of') == canonical_event:
+        if kwargs.get(LEGACY_ALIAS_FIELD) == canonical_event:
             return
         handler(*args, **kwargs)
 

--- a/ecs/systems/condition_system.py
+++ b/ecs/systems/condition_system.py
@@ -25,6 +25,7 @@ from ecs.components.health import HealthComponent
 from ecs.components.initiative import InitiativeComponent
 from ecs.components.willpower import WillpowerComponent
 from ecs.ecs_manager import ECSManager
+from interface.event_constants import CoreEvents
 from utils.condition_utils import (
     WEAKENED_PHYSICAL,
     WEAKENED_MENTAL_SOCIAL,
@@ -128,9 +129,13 @@ class ConditionSystem:
         bus = self.event_bus
         if not bus:
             return
-        bus.subscribe('round_started', self._on_round_started)
+        bus.subscribe(CoreEvents.ROUND_START, self._on_round_started)
+        if CoreEvents.ROUND_START != "round_started":
+            bus.subscribe("round_started", self._on_round_started_legacy)
         bus.subscribe('damage_inflicted', self._on_damage_inflicted)
-        bus.subscribe('turn_started', self._on_turn_started)
+        bus.subscribe(CoreEvents.TURN_START, self._on_turn_started)
+        if CoreEvents.TURN_START != "turn_started":
+            bus.subscribe("turn_started", self._on_turn_started_legacy)
 
     # Registration helpers --------------------------------------------------
     def register_start_turn_handler(self, condition_name: str, func: Any):
@@ -635,6 +640,16 @@ class ConditionSystem:
             gs_bus = getattr(self.game_state, 'event_bus', None)
             if not published or gs_bus is None or gs_bus is not self.event_bus:
                 self.game_state.bump_blocker_version()
+
+    def _on_round_started_legacy(self, **evt):
+        if evt.get('_legacy_alias_of') == CoreEvents.ROUND_START:
+            return
+        self._on_round_started(**evt)
+
+    def _on_turn_started_legacy(self, entity_id: str, **evt):
+        if evt.get('_legacy_alias_of') == CoreEvents.TURN_START:
+            return
+        self._on_turn_started(entity_id, **evt)
 
     def _on_round_started(self, **evt):
         expired = []

--- a/ecs/systems/condition_system.py
+++ b/ecs/systems/condition_system.py
@@ -655,7 +655,12 @@ class ConditionSystem:
         self._forward_legacy_alias(self._on_round_started, CoreEvents.ROUND_START, **evt)
 
     def _on_turn_started_legacy(self, entity_id: str, **evt):
-        self._forward_legacy_alias(self._on_turn_started, CoreEvents.TURN_START, entity_id, **evt)
+        self._forward_legacy_alias(
+            self._on_turn_started,
+            CoreEvents.TURN_START,
+            entity_id=entity_id,
+            **evt,
+        )
 
     def _forward_legacy_alias(
         self,
@@ -664,6 +669,10 @@ class ConditionSystem:
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        # Prevent infinite forwarding loops by respecting the alias marker inserted by
+        # the publishing system. This relies on publishers providing the marker when
+        # they emit legacy-compatible events; if the canonical event shows up through
+        # the legacy channel we bail out instead of invoking the handler again.
         if kwargs.get(LEGACY_ALIAS_FIELD) == canonical_event:
             return
         handler(*args, **kwargs)

--- a/ecs/systems/turn_order_system.py
+++ b/ecs/systems/turn_order_system.py
@@ -51,7 +51,7 @@ from typing import List, Dict, Any, Tuple, Optional
 from ecs.components.character_ref import CharacterRefComponent
 from ecs.components.entity_id import EntityIdComponent
 from ecs.components.initiative import InitiativeComponent
-from interface.event_constants import CoreEvents
+from interface.event_constants import CoreEvents, LEGACY_ALIAS_FIELD
 
 
 class TurnOrderSystem:
@@ -296,5 +296,5 @@ class TurnOrderSystem:
         self.event_bus.publish(event_name, **payload)
         if legacy_name and legacy_name != event_name:
             legacy_payload = dict(payload)
-            legacy_payload.setdefault("_legacy_alias_of", event_name)
+            legacy_payload.setdefault(LEGACY_ALIAS_FIELD, event_name)
             self.event_bus.publish(legacy_name, **legacy_payload)

--- a/ecs/systems/turn_order_system.py
+++ b/ecs/systems/turn_order_system.py
@@ -46,7 +46,7 @@ Example:
     turn_system.delay_current_entity()
 """
 import random
-from typing import List, Dict, Any, Tuple, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from ecs.components.character_ref import CharacterRefComponent
 from ecs.components.entity_id import EntityIdComponent

--- a/interface/event_constants.py
+++ b/interface/event_constants.py
@@ -44,3 +44,6 @@ ALL_EVENTS: Tuple[str, ...] = (
 def list_all_events() -> List[str]:
     return list(ALL_EVENTS)
 
+
+LEGACY_ALIAS_FIELD = "_legacy_alias_of"
+


### PR DESCRIPTION
## Summary
- update the turn order system to publish CoreEvents round and turn lifecycle events while still mirroring the legacy aliases for compatibility
- switch condition system subscriptions to CoreEvents while providing legacy adapters so existing publishers continue to work
- stabilize initiative tie-breaking with an internal RNG to keep ordering deterministic during tests
- restore nondeterministic initiative tie-breaking so live games retain organic ordering

## Testing
- pytest tests/unit/test_turn_order_system.py tests/unit/test_conditions.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dff0ac546c832da8743d28600c726b