### PR TITLE
Add action catalog and selector for core actions

### DIFF
--- a/core/actions/catalog.py
+++ b/core/actions/catalog.py
@@ -1,0 +1,124 @@
+"""Static catalog of declarative action definitions.
+
+This module exposes :class:`ActionDef`, a lightweight dataclass describing the
+properties of an action without tying it to runtime systems.  The catalog is
+intended to be consumed by selection and validation layers so they can reason
+about what an actor *could* do before any state mutation occurs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from core.actions.intent import CostSpec
+
+
+Prerequisite = Callable[..., bool] | str
+TargetingMode = Mapping[str, Any] | str
+
+
+@dataclass(frozen=True, slots=True)
+class ActionDef:
+    """Declarative description of an action available in the catalog."""
+
+    id: str
+    name: str
+    category: str
+    targeting: Sequence[TargetingMode] = field(default_factory=tuple)
+    costs: CostSpec = field(default_factory=CostSpec)
+    tags: Sequence[str] = field(default_factory=tuple)
+    prereqs: Sequence[Prerequisite] = field(default_factory=tuple)
+    effects: str | None = None
+    reaction_speed: str = "none"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Provide a serialisable representation of the action definition."""
+
+        return {
+            "id": self.id,
+            "name": self.name,
+            "category": self.category,
+            "targeting": list(self.targeting),
+            "costs": self.costs.to_dict(),
+            "tags": list(self.tags),
+            "prereqs": list(self.prereqs),
+            "effects": self.effects,
+            "reaction_speed": self.reaction_speed,
+        }
+
+
+ACTION_CATALOG: dict[str, ActionDef] = {
+    "move": ActionDef(
+        id="move",
+        name="Move",
+        category="move",
+        targeting=(
+            {
+                "kind": "tile",
+                "prompt": "Destination tile (x,y)",
+            },
+        ),
+        costs=CostSpec(movement_points=1),
+        tags=("basic", "movement"),
+        effects="queue_move",
+    ),
+    "attack_melee": ActionDef(
+        id="attack_melee",
+        name="Melee Attack",
+        category="attack",
+        targeting=(
+            {
+                "kind": "entity",
+                "prompt": "Select adjacent enemy",
+            },
+        ),
+        costs=CostSpec(action_points=1),
+        tags=("attack", "melee"),
+        effects="queue_melee_attack",
+    ),
+    "attack_ranged": ActionDef(
+        id="attack_ranged",
+        name="Ranged Attack",
+        category="attack",
+        targeting=(
+            {
+                "kind": "entity",
+                "prompt": "Select visible enemy",
+            },
+        ),
+        costs=CostSpec(action_points=1, ammunition=1),
+        tags=("attack", "ranged"),
+        effects="queue_ranged_attack",
+    ),
+    "defend_dodge": ActionDef(
+        id="defend_dodge",
+        name="Dodge",
+        category="defense",
+        targeting=(
+            {
+                "kind": "self",
+            },
+        ),
+        costs=CostSpec(action_points=1),
+        tags=("defense", "reaction"),
+        effects="queue_dodge",
+        reaction_speed="fast",
+    ),
+    "discipline_generic": ActionDef(
+        id="discipline_generic",
+        name="Discipline Power",
+        category="discipline",
+        targeting=(),
+        costs=CostSpec(action_points=1, willpower=1),
+        tags=("discipline",),
+        effects="queue_discipline_effect",
+    ),
+}
+
+
+def iter_catalog() -> Iterable[ActionDef]:
+    """Helper returning a stable iteration over catalog entries."""
+
+    return ACTION_CATALOG.values()
+

--- a/core/actions/selector.py
+++ b/core/actions/selector.py
@@ -224,24 +224,42 @@ def _iter_enemy_ids(rules_context: Any, actor_id: str) -> Iterable[str]:
     return iterable
 
 
+def _coerce_position(value: Any) -> Optional[tuple[int, int]]:
+    if value is None or isinstance(value, (str, bytes)):
+        return None
+
+    try:
+        x, y = value
+    except (TypeError, ValueError):
+        return None
+
+    try:
+        return int(x), int(y)
+    except (TypeError, ValueError):
+        return None
+
+
 def _get_position(entity_id: str, ecs: Any, rules_context: Any) -> Optional[tuple[int, int]]:
     getter = getattr(rules_context, "get_position", None)
     if callable(getter):
         position = getter(entity_id)
-        if position is not None:
-            return tuple(position)
+        coerced = _coerce_position(position)
+        if coerced is not None:
+            return coerced
 
     getter = getattr(ecs, "get_position", None)
     if callable(getter):
         position = getter(entity_id)
-        if position is not None:
-            return tuple(position)
+        coerced = _coerce_position(position)
+        if coerced is not None:
+            return coerced
 
     positions = getattr(ecs, "positions", None)
     if isinstance(positions, Mapping):
         value = positions.get(entity_id)
-        if value is not None:
-            return tuple(value)
+        coerced = _coerce_position(value)
+        if coerced is not None:
+            return coerced
 
     return None
 

--- a/core/actions/selector.py
+++ b/core/actions/selector.py
@@ -81,18 +81,15 @@ def _evaluate_action(action_def: ActionDef, actor_id: str, ecs: Any, rules_conte
         _check_costs(action_def, actor_id, ecs, rules_context)
     )
 
-    if action_def.id == "move":
-        targets, hints, failures = _compute_move_targets(actor_id, ecs, rules_context)
-        valid_targets.extend(targets)
-        ui_hints.update(hints)
-        predicates_failed.extend(failures)
-    elif action_def.id == "attack_melee":
-        targets, hints, failures = _compute_melee_targets(actor_id, ecs, rules_context)
-        valid_targets.extend(targets)
-        ui_hints.update(hints)
-        predicates_failed.extend(failures)
-    elif action_def.id == "attack_ranged":
-        targets, hints, failures = _compute_ranged_targets(actor_id, ecs, rules_context)
+    target_resolvers = {
+        "move": _compute_move_targets,
+        "attack_melee": _compute_melee_targets,
+        "attack_ranged": _compute_ranged_targets,
+    }
+
+    resolver = target_resolvers.get(action_def.id)
+    if resolver is not None:
+        targets, hints, failures = resolver(actor_id, ecs, rules_context)
         valid_targets.extend(targets)
         ui_hints.update(hints)
         predicates_failed.extend(failures)

--- a/core/actions/selector.py
+++ b/core/actions/selector.py
@@ -259,9 +259,12 @@ def _get_position(entity_id: str, ecs: Any, rules_context: Any) -> Optional[tupl
 
 
 def _manhattan_distance(a: Sequence[int], b: Sequence[int]) -> int:
-    if len(a) != len(b):
+    len_a = len(a)
+    len_b = len(b)
+    if len_a != len_b:
         raise ValueError(
             "Cannot compute Manhattan distance: sequences have different lengths"
+            f" ({len_a} != {len_b})"
         )
 
     return sum(abs(int(x) - int(y)) for x, y in zip(a, b))

--- a/core/actions/selector.py
+++ b/core/actions/selector.py
@@ -260,8 +260,8 @@ def _manhattan_distance(a: Sequence[int], b: Sequence[int]) -> int:
     len_b = len(b)
     if len_a != len_b:
         raise ValueError(
-            "Cannot compute Manhattan distance: sequences have different lengths"
-            f" ({len_a} != {len_b})"
+            "Cannot compute Manhattan distance: sequences have different lengths "
+            f"({len_a} != {len_b})"
         )
 
     return sum(abs(int(x) - int(y)) for x, y in zip(a, b))

--- a/core/actions/selector.py
+++ b/core/actions/selector.py
@@ -36,17 +36,16 @@ class ActionOption:
         return not self.predicates_failed and bool(self.valid_targets or self._accepts_free_targeting)
 
     def to_payload(self) -> dict[str, Any]:
-        targets_payload: list[Any] = []
-        for entry in self.valid_targets:
-            targets_payload.append(entry.to_dict())
+        definition = self.definition
+        targets_payload = [entry.to_dict() for entry in self.valid_targets]
 
         return {
-            "id": self.definition.id,
-            "name": self.definition.name,
-            "category": self.definition.category,
+            "id": definition.id,
+            "name": definition.name,
+            "category": definition.category,
             "targets": targets_payload,
             "ui_hints": dict(self.ui_hints),
-            "tags": list(self.definition.tags),
+            "tags": list(definition.tags),
             "predicates_failed": list(self.predicates_failed),
             "available": self.is_available,
         }

--- a/core/actions/selector.py
+++ b/core/actions/selector.py
@@ -1,0 +1,324 @@
+"""Computation of the currently available actions for an actor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Optional, Protocol, Sequence
+
+from core.actions.catalog import ACTION_CATALOG, ActionDef, iter_catalog
+from core.actions.intent import TargetSpec
+from core.events import topics
+
+
+class EventBusLike(Protocol):
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        ...
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        ...
+
+
+TargetResolver = Callable[[str, Any, Any], Sequence[TargetSpec]]
+
+
+@dataclass(slots=True)
+class ActionOption:
+    """Action candidate enriched with gameplay metadata."""
+
+    definition: ActionDef
+    valid_targets: list[TargetSpec | TargetResolver] = field(default_factory=list)
+    ui_hints: Mapping[str, Any] = field(default_factory=dict)
+    predicates_failed: list[str] = field(default_factory=list)
+
+    @property
+    def action_id(self) -> str:
+        return self.definition.id
+
+    @property
+    def is_available(self) -> bool:
+        return not self.predicates_failed and bool(self.valid_targets or self._accepts_free_targeting)
+
+    def to_payload(self) -> dict[str, Any]:
+        targets_payload: list[Any] = []
+        for entry in self.valid_targets:
+            if isinstance(entry, TargetSpec):
+                targets_payload.append(entry.to_dict())
+            else:
+                targets_payload.append(entry)
+
+        return {
+            "id": self.definition.id,
+            "name": self.definition.name,
+            "category": self.definition.category,
+            "targets": targets_payload,
+            "ui_hints": dict(self.ui_hints),
+            "tags": list(self.definition.tags),
+            "predicates_failed": list(self.predicates_failed),
+            "available": self.is_available,
+        }
+
+    @property
+    def _accepts_free_targeting(self) -> bool:
+        return not self.definition.targeting
+
+
+def compute_available_actions(actor_id: str, ecs: Any, rules_context: Any) -> list[ActionOption]:
+    """Return declarative action options for the given actor."""
+
+    options: list[ActionOption] = []
+
+    for action_def in iter_catalog():
+        if action_def.reaction_speed and action_def.reaction_speed != "none":
+            # Reactions are handled in dedicated windows.
+            continue
+
+        option = _evaluate_action(action_def, actor_id, ecs, rules_context)
+        options.append(option)
+
+    return options
+
+
+def _evaluate_action(action_def: ActionDef, actor_id: str, ecs: Any, rules_context: Any) -> ActionOption:
+    predicates_failed: list[str] = []
+    valid_targets: list[TargetSpec | TargetResolver] = []
+    ui_hints: dict[str, Any] = {}
+
+    predicates_failed.extend(
+        _check_costs(action_def, actor_id, ecs, rules_context)
+    )
+
+    if action_def.id == "move":
+        targets, hints, failures = _compute_move_targets(actor_id, ecs, rules_context)
+        valid_targets.extend(targets)
+        ui_hints.update(hints)
+        predicates_failed.extend(failures)
+    elif action_def.id == "attack_melee":
+        targets, hints, failures = _compute_melee_targets(actor_id, ecs, rules_context)
+        valid_targets.extend(targets)
+        ui_hints.update(hints)
+        predicates_failed.extend(failures)
+    elif action_def.id == "attack_ranged":
+        targets, hints, failures = _compute_ranged_targets(actor_id, ecs, rules_context)
+        valid_targets.extend(targets)
+        ui_hints.update(hints)
+        predicates_failed.extend(failures)
+    elif action_def.id == "discipline_generic":
+        ui_hints.setdefault("description", "Invoke a discipline power")
+
+    if not valid_targets and not predicates_failed and action_def.targeting:
+        predicates_failed.append("no_valid_targets")
+
+    return ActionOption(
+        definition=action_def,
+        valid_targets=valid_targets,
+        ui_hints=ui_hints,
+        predicates_failed=predicates_failed,
+    )
+
+
+def _compute_move_targets(actor_id: str, ecs: Any, rules_context: Any):
+    movement_system = getattr(rules_context, "movement_system", None)
+    if movement_system is None:
+        return [], {}, ["movement_system_unavailable"]
+
+    move_budget = _call_optional(rules_context, "get_movement_budget", actor_id)
+    move_distance = _call_optional(rules_context, "get_move_distance", actor_id)
+    if move_distance is None:
+        move_distance = move_budget
+
+    if not move_distance or move_distance <= 0:
+        return [], {}, ["insufficient_movement"]
+
+    reachable: Iterable[tuple[int, int, int]] = movement_system.get_reachable_tiles(actor_id, move_distance)
+    targets = [
+        TargetSpec.tile((x, y), cost=cost)
+        for x, y, cost in reachable
+    ]
+
+    if not targets:
+        return targets, {"range": move_distance, "mode": "tile"}, ["no_reachable_tiles"]
+
+    hints = {"range": move_distance, "mode": "tile"}
+    return targets, hints, []
+
+
+def _compute_melee_targets(actor_id: str, ecs: Any, rules_context: Any):
+    enemies = list(_iter_enemy_ids(rules_context, actor_id))
+    if not enemies:
+        return [], {}, ["no_enemies"]
+
+    actor_pos = _get_position(actor_id, ecs, rules_context)
+    if actor_pos is None:
+        return [], {}, ["position_unknown"]
+
+    los_system = getattr(rules_context, "line_of_sight", None)
+    valid: list[TargetSpec] = []
+    for enemy_id in enemies:
+        enemy_pos = _get_position(enemy_id, ecs, rules_context)
+        if enemy_pos is None:
+            continue
+        if _manhattan_distance(actor_pos, enemy_pos) != 1:
+            continue
+        if los_system and not los_system.has_line_of_sight(actor_id, enemy_id):
+            continue
+        valid.append(TargetSpec.entity(enemy_id, distance=1))
+
+    if not valid:
+        return valid, {"range": 1, "mode": "entity"}, ["no_adjacent_enemies"]
+
+    hints = {"range": 1, "mode": "entity", "weapon": "melee"}
+    return valid, hints, []
+
+
+def _compute_ranged_targets(actor_id: str, ecs: Any, rules_context: Any):
+    enemies = list(_iter_enemy_ids(rules_context, actor_id))
+    if not enemies:
+        return [], {}, ["no_enemies"]
+
+    actor_pos = _get_position(actor_id, ecs, rules_context)
+    if actor_pos is None:
+        return [], {}, ["position_unknown"]
+
+    max_range = _call_optional(rules_context, "get_ranged_range", actor_id)
+    if max_range is None:
+        max_range = _call_optional(rules_context, "get_default_ranged_range", actor_id)
+    if max_range is None:
+        max_range = 6
+
+    if max_range <= 0:
+        return [], {}, ["no_ranged_weapon"]
+
+    los_system = getattr(rules_context, "line_of_sight", None)
+    valid: list[TargetSpec] = []
+    for enemy_id in enemies:
+        enemy_pos = _get_position(enemy_id, ecs, rules_context)
+        if enemy_pos is None:
+            continue
+        distance = _manhattan_distance(actor_pos, enemy_pos)
+        if distance > max_range:
+            continue
+        if los_system and not los_system.has_line_of_sight(actor_id, enemy_id):
+            continue
+        valid.append(TargetSpec.entity(enemy_id, distance=distance))
+
+    if not valid:
+        return valid, {"range": max_range, "mode": "entity"}, ["no_targets_in_range"]
+
+    hints = {"range": max_range, "mode": "entity", "weapon": "ranged"}
+    return valid, hints, []
+
+
+def _call_optional(context: Any, attr: str, *args: Any) -> Any:
+    candidate = getattr(context, attr, None)
+    if callable(candidate):
+        return candidate(*args)
+    return None
+
+
+def _iter_enemy_ids(rules_context: Any, actor_id: str) -> Iterable[str]:
+    iterable = _call_optional(rules_context, "iter_enemy_ids", actor_id)
+    if iterable is None:
+        iterable = _call_optional(rules_context, "get_enemy_ids", actor_id)
+    if iterable is None:
+        return ()
+    return iterable
+
+
+def _get_position(entity_id: str, ecs: Any, rules_context: Any) -> Optional[tuple[int, int]]:
+    getter = getattr(rules_context, "get_position", None)
+    if callable(getter):
+        position = getter(entity_id)
+        if position is not None:
+            return tuple(position)
+
+    getter = getattr(ecs, "get_position", None)
+    if callable(getter):
+        position = getter(entity_id)
+        if position is not None:
+            return tuple(position)
+
+    positions = getattr(ecs, "positions", None)
+    if isinstance(positions, Mapping):
+        value = positions.get(entity_id)
+        if value is not None:
+            return tuple(value)
+
+    return None
+
+
+def _manhattan_distance(a: Sequence[int], b: Sequence[int]) -> int:
+    return sum(abs(int(x) - int(y)) for x, y in zip(a, b))
+
+
+def _check_costs(action_def: ActionDef, actor_id: str, ecs: Any, rules_context: Any) -> list[str]:
+    failures: list[str] = []
+    costs = action_def.costs
+    cost_items = costs.to_dict().items()
+    for resource, required in cost_items:
+        if required <= 0:
+            continue
+        available = _resolve_resource(actor_id, resource, ecs, rules_context)
+        if available is None:
+            continue
+        if available < required:
+            failures.append(f"insufficient_{resource}")
+    return failures
+
+
+def _resolve_resource(actor_id: str, resource: str, ecs: Any, rules_context: Any) -> Optional[int]:
+    getter_name_variants = [
+        f"get_{resource}",
+        f"get_{resource}_points",
+        f"get_{resource}_pool",
+        f"get_{resource}_remaining",
+    ]
+    for name in getter_name_variants:
+        value = _call_optional(rules_context, name, actor_id)
+        if value is not None:
+            return int(value)
+
+    accessor = getattr(ecs, resource, None)
+    if isinstance(accessor, Mapping):
+        value = accessor.get(actor_id)
+        if value is not None:
+            return int(value)
+
+    getter = getattr(ecs, f"get_{resource}", None)
+    if callable(getter):
+        value = getter(actor_id)
+        if value is not None:
+            return int(value)
+
+    return None
+
+
+class ActionSelector:
+    """Event-driven wrapper around :func:`compute_available_actions`."""
+
+    def __init__(self, ecs: Any, rules_context: Any) -> None:
+        self._ecs = ecs
+        self._rules = rules_context
+        self._bus: EventBusLike | None = None
+
+    def bind(self, event_bus: EventBusLike) -> None:
+        self._bus = event_bus
+        event_bus.subscribe(topics.REQUEST_ACTIONS, self._handle_request_actions)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _handle_request_actions(self, *, actor_id: str, **payload: Any) -> None:
+        if self._bus is None:
+            return
+
+        options = compute_available_actions(str(actor_id), self._ecs, self._rules)
+        actions_payload = [option.to_payload() for option in options]
+
+        publish_payload = {
+            "actor_id": str(actor_id),
+            "actions": actions_payload,
+        }
+        publish_payload.update({k: v for k, v in payload.items() if k not in publish_payload})
+
+        self._bus.publish(topics.ACTIONS_AVAILABLE, **publish_payload)
+

--- a/tests/unit/actions/test_catalog.py
+++ b/tests/unit/actions/test_catalog.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from core.actions.catalog import ACTION_CATALOG, ActionDef, iter_catalog
+
+
+def test_catalog_contains_expected_entries() -> None:
+    expected_ids = {"move", "attack_melee", "attack_ranged", "defend_dodge", "discipline_generic"}
+    assert expected_ids <= set(ACTION_CATALOG)
+
+    move_def = ACTION_CATALOG["move"]
+    assert isinstance(move_def, ActionDef)
+    assert move_def.category == "move"
+    assert move_def.reaction_speed == "none"
+
+    dodge_def = ACTION_CATALOG["defend_dodge"]
+    assert dodge_def.reaction_speed == "fast"
+    assert "reaction" in dodge_def.tags
+
+
+def test_iter_catalog_returns_stable_sequence() -> None:
+    first = list(iter_catalog())
+    second = list(iter_catalog())
+    assert [action.id for action in first] == [action.id for action in second]

--- a/tests/unit/actions/test_selector.py
+++ b/tests/unit/actions/test_selector.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from core.actions.selector import ActionOption, ActionSelector, compute_available_actions
+from core.events import topics
+
+
+@dataclass
+class StubMovementSystem:
+    reachable: list[tuple[int, int, int]]
+
+    def get_reachable_tiles(self, actor_id: str, max_distance: int):
+        assert max_distance > 0
+        return self.reachable
+
+
+class StubLineOfSight:
+    def __init__(self, visible_pairs: set[tuple[str, str]]) -> None:
+        self.visible_pairs = visible_pairs
+
+    def has_line_of_sight(self, source_id: str, target_id: str) -> bool:
+        return (source_id, target_id) in self.visible_pairs
+
+
+class DummyRulesContext:
+    def __init__(self) -> None:
+        self.movement_system = StubMovementSystem(
+            reachable=[(1, 0, 1), (0, 1, 1)]
+        )
+        self.line_of_sight = StubLineOfSight({("hero", "ghoul"), ("hero", "vampire")})
+
+    def get_movement_budget(self, actor_id: str) -> int:
+        return 4
+
+    def get_move_distance(self, actor_id: str) -> int:
+        return 4
+
+    def get_ranged_range(self, actor_id: str) -> int:
+        return 6
+
+    def iter_enemy_ids(self, actor_id: str):
+        return ["ghoul", "vampire"]
+
+    def get_position(self, entity_id: str):
+        positions = {
+            "hero": (0, 0),
+            "ghoul": (0, 1),
+            "vampire": (3, 0),
+        }
+        return positions.get(entity_id)
+
+    def get_action_points(self, actor_id: str) -> int:
+        return 2
+
+    def get_ammunition(self, actor_id: str) -> int:
+        return 5
+
+
+class DummyECS:
+    def __init__(self) -> None:
+        self.positions = {"hero": (0, 0), "ghoul": (0, 1), "vampire": (3, 0)}
+
+
+def test_compute_available_actions_core_paths() -> None:
+    ecs = DummyECS()
+    ctx = DummyRulesContext()
+
+    options = compute_available_actions("hero", ecs, ctx)
+    option_map = {opt.action_id: opt for opt in options}
+
+    move_option = option_map["move"]
+    assert isinstance(move_option, ActionOption)
+    assert move_option.is_available
+    assert len(move_option.valid_targets) == 2
+
+    melee_option = option_map["attack_melee"]
+    assert melee_option.is_available
+    assert any(target.to_dict()["reference"] == "ghoul" for target in melee_option.valid_targets)  # type: ignore[union-attr]
+
+    ranged_option = option_map["attack_ranged"]
+    assert ranged_option.is_available
+    assert len(ranged_option.valid_targets) == 2
+
+    assert "defend_dodge" not in option_map
+
+
+def test_compute_available_actions_handles_blockers() -> None:
+    ecs = DummyECS()
+    ctx = DummyRulesContext()
+    ctx.movement_system.reachable = []
+
+    options = compute_available_actions("hero", ecs, ctx)
+    move_option = next(opt for opt in options if opt.action_id == "move")
+
+    assert not move_option.is_available
+    assert "no_reachable_tiles" in move_option.predicates_failed
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.subscriptions: dict[str, list[Callable[..., None]]] = {}
+        self.published: list[tuple[str, dict[str, object]]] = []
+
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        self.subscriptions.setdefault(topic, []).append(handler)
+
+    def publish(self, topic: str, /, **payload: object) -> None:
+        self.published.append((topic, dict(payload)))
+        for handler in self.subscriptions.get(topic, []):
+            handler(**payload)
+
+
+def test_action_selector_publishes_on_bus() -> None:
+    ecs = DummyECS()
+    ctx = DummyRulesContext()
+    selector = ActionSelector(ecs, ctx)
+    bus = DummyEventBus()
+
+    selector.bind(bus)
+    bus.publish(topics.REQUEST_ACTIONS, actor_id="hero")
+
+    assert any(topic == topics.ACTIONS_AVAILABLE for topic, _ in bus.published)
+    published_payloads = [payload for topic, payload in bus.published if topic == topics.ACTIONS_AVAILABLE]
+    assert published_payloads
+    payload = published_payloads[-1]
+    assert payload["actor_id"] == "hero"
+    assert any(action["id"] == "move" for action in payload["actions"])  # type: ignore[index]

--- a/tests/unit/actions/test_selector.py
+++ b/tests/unit/actions/test_selector.py
@@ -77,7 +77,8 @@ def test_compute_available_actions_core_paths() -> None:
 
     melee_option = option_map["attack_melee"]
     assert melee_option.is_available
-    assert any(target.to_dict()["reference"] == "ghoul" for target in melee_option.valid_targets)  # type: ignore[union-attr]
+    target_refs = [target.to_dict()["reference"] for target in melee_option.valid_targets]
+    assert "ghoul" in target_refs
 
     ranged_option = option_map["attack_ranged"]
     assert ranged_option.is_available

--- a/tests/unit/actions/test_selector.py
+++ b/tests/unit/actions/test_selector.py
@@ -132,7 +132,10 @@ def test_action_selector_publishes_on_bus() -> None:
     assert published_payloads
     payload = published_payloads[-1]
     assert payload["actor_id"] == "hero"
-    assert any(action["id"] == "move" for action in payload["actions"])  # type: ignore[index]
+    actions = payload["actions"]
+    assert isinstance(actions, list)
+    action_ids = [action["id"] for action in actions if isinstance(action, dict)]
+    assert "move" in action_ids
 
 
 def test_manhattan_distance_raises_on_mismatched_lengths() -> None:

--- a/tests/unit/actions/test_selector.py
+++ b/tests/unit/actions/test_selector.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from core.actions.selector import ActionOption, ActionSelector, compute_available_actions
+from core.actions.selector import (
+    ActionOption,
+    ActionSelector,
+    _manhattan_distance,
+    compute_available_actions,
+)
 from core.events import topics
 
 
@@ -128,3 +133,12 @@ def test_action_selector_publishes_on_bus() -> None:
     payload = published_payloads[-1]
     assert payload["actor_id"] == "hero"
     assert any(action["id"] == "move" for action in payload["actions"])  # type: ignore[index]
+
+
+def test_manhattan_distance_raises_on_mismatched_lengths() -> None:
+    try:
+        _manhattan_distance((0, 0), (1, 2, 3))
+    except ValueError as exc:
+        assert "2 != 3" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for mismatched coordinate lengths")


### PR DESCRIPTION
## Summary
- add a static catalog describing move, attack, defense, and discipline actions
- compute actionable targets for move, melee, and ranged options while skipping reactions
- publish selector results on the event bus and cover the behavior with unit tests

## Testing
- pytest tests/unit/actions/test_catalog.py tests/unit/actions/test_selector.py

------
https://chatgpt.com/codex/tasks/task_e_68e02a47eecc832da1e7ce08c6588c01