### PR TITLE
Implement action validation, scheduling, performance, and reactions

### DIFF
--- a/core/actions/performers.py
+++ b/core/actions/performers.py
@@ -1,0 +1,126 @@
+"""Action performers translating queued actions into system side-effects."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Mapping, Optional, Protocol
+
+from core.actions.intent import ActionIntent, TargetSpec
+from core.events import topics
+
+
+class EventBusLike(Protocol):
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        ...
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        ...
+
+
+class ActionPerformer:
+    """Dispatch ``PERFORM_ACTION`` events to the appropriate subsystems."""
+
+    def __init__(self, rules_ctx: Any) -> None:
+        self._rules = rules_ctx
+        self._bus: EventBusLike | None = None
+
+    def bind(self, bus: EventBusLike) -> None:
+        self._bus = bus
+        bus.subscribe(topics.PERFORM_ACTION, self._handle_perform_action)
+
+    # ------------------------------------------------------------------
+    def _handle_perform_action(self, *, intent: Any, intent_obj: Any | None = None, await_reactions: bool | None = None, reactions_resolved: bool | None = None, **payload: Any) -> None:
+        if self._bus is None:
+            return
+
+        if await_reactions and not reactions_resolved:
+            # Wait for reaction manager to re-dispatch the event.
+            return
+
+        normalised = _ensure_intent(intent_obj, intent)
+        action_id = normalised.action_id
+        handler = getattr(self, f"_perform_{action_id}", None)
+        if callable(handler):
+            result = handler(normalised, payload)
+        else:
+            result = self._perform_generic(normalised, payload)
+
+        publish_payload = {
+            "actor_id": normalised.actor_id,
+            "action_id": normalised.action_id,
+            "intent": normalised.to_dict(),
+            "result": result,
+        }
+        publish_payload.update(payload)
+        self._bus.publish(topics.ACTION_RESOLVED, **publish_payload)
+
+    # ------------------------------------------------------------------
+    # Concrete performers
+    # ------------------------------------------------------------------
+    def _perform_move(self, intent: ActionIntent, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        movement_system = getattr(self._rules, "movement_system", None)
+        destination = _first_tile(intent.targets)
+        success = False
+        if movement_system and destination:
+            steps = payload.get("max_steps")
+            try:
+                success = bool(movement_system.move(intent.actor_id, destination, max_steps=steps))
+            except TypeError:
+                success = bool(movement_system.move(intent.actor_id, destination))
+        return {"success": success, "destination": destination}
+
+    def _perform_attack_melee(self, intent: ActionIntent, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self._execute_attack("melee", intent, payload)
+
+    def _perform_attack_ranged(self, intent: ActionIntent, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self._execute_attack("ranged", intent, payload)
+
+    def _perform_generic(self, intent: ActionIntent, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {"handled": False, "payload": dict(payload)}
+
+    # ------------------------------------------------------------------
+    def _execute_attack(self, kind: str, intent: ActionIntent, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        resolver = getattr(self._rules, "resolve_attack", None)
+        target_id = _first_entity(intent.targets)
+        result: dict[str, Any] = {
+            "kind": kind,
+            "target": target_id,
+        }
+        if callable(resolver) and target_id:
+            outcome = resolver(intent.actor_id, target_id, intent=intent, payload=payload, kind=kind)
+            if isinstance(outcome, Mapping):
+                result.update(outcome)
+        else:
+            # Minimal deterministic placeholder.
+            result.setdefault("hit", bool(target_id))
+            result.setdefault("damage", 1 if target_id else 0)
+        return result
+
+
+def _ensure_intent(intent_obj: Any | None, payload: Any) -> ActionIntent:
+    if isinstance(intent_obj, ActionIntent):
+        return intent_obj
+    if isinstance(payload, ActionIntent):
+        return payload
+    if isinstance(payload, Mapping):
+        return ActionIntent.from_dict(payload)
+    raise TypeError("Intent payload is neither mapping nor ActionIntent")
+
+
+def _first_tile(targets: Iterable[TargetSpec]) -> Optional[tuple[int, int]]:
+    for target in targets:
+        if target.kind == "tile" and target.position is not None:
+            coords = target.position
+            if len(coords) >= 2:
+                return int(coords[0]), int(coords[1])
+    return None
+
+
+def _first_entity(targets: Iterable[TargetSpec]) -> Optional[str]:
+    for target in targets:
+        if target.kind == "entity" and target.reference:
+            return target.reference
+    return None
+
+
+__all__ = ["ActionPerformer"]
+

--- a/core/actions/scheduler.py
+++ b/core/actions/scheduler.py
@@ -1,0 +1,123 @@
+"""Action scheduling layer bridging validated intents and execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional, Protocol
+
+from core.actions.catalog import ACTION_CATALOG, ActionDef
+from core.actions.intent import ActionIntent
+from core.events import topics
+from ecs.components.action_budget import ActionBudgetComponent
+
+
+class EventBusLike(Protocol):
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        ...
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        ...
+
+
+@dataclass
+class ReservationResult:
+    actor_id: str
+    action_id: str
+    costs: Mapping[str, int]
+    reservation_id: Optional[str]
+
+
+class ActionScheduler:
+    """Reserve action budgets and trigger execution."""
+
+    def __init__(self, ecs: Any) -> None:
+        self._ecs = ecs
+        self._bus: EventBusLike | None = None
+        self._fallback_budgets: dict[str, ActionBudgetComponent] = {}
+
+    def bind(self, bus: EventBusLike) -> None:
+        self._bus = bus
+        bus.subscribe(topics.INTENT_VALIDATED, self._handle_intent_validated)
+
+    # ------------------------------------------------------------------
+    # Internal handlers
+    # ------------------------------------------------------------------
+    def _handle_intent_validated(self, *, intent: Any, intent_obj: Any | None = None, **extra: Any) -> None:
+        if self._bus is None:
+            return
+
+        normalised = _ensure_intent(intent_obj, intent)
+        action_def = ACTION_CATALOG.get(normalised.action_id)
+        if action_def is None:
+            return
+
+        costs = action_def.costs.to_dict()
+        reservation_id = extra.get("reservation_id") or normalised.client_tx_id
+
+        budget_component = self._ensure_budget_component(normalised.actor_id)
+        budget_component.reserve(costs, transaction_id=reservation_id)
+
+        payload = {
+            "actor_id": normalised.actor_id,
+            "action_id": normalised.action_id,
+            "intent": normalised.to_dict(),
+            "intent_obj": normalised,
+            "costs": costs,
+            "reservation_id": reservation_id,
+        }
+        payload.update(extra)
+
+        reactionable = _is_reactionable(action_def)
+        if reactionable:
+            payload.setdefault("await_reactions", True)
+        else:
+            payload.setdefault("await_reactions", False)
+
+        self._bus.publish(topics.ACTION_ENQUEUED, **payload)
+        self._bus.publish(topics.PERFORM_ACTION, **payload)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _ensure_budget_component(self, actor_id: str) -> ActionBudgetComponent:
+        resolver = getattr(self._ecs, "resolve_entity", None)
+        try_get = getattr(self._ecs, "try_get_component", None)
+        add_component = getattr(self._ecs, "add_component", None)
+
+        if callable(resolver) and callable(try_get) and callable(add_component):
+            internal_id = resolver(actor_id)
+            if internal_id is not None:
+                component = try_get(internal_id, ActionBudgetComponent)
+                if component is None:
+                    component = ActionBudgetComponent()
+                    add_component(internal_id, component)
+                return component
+
+        component = self._fallback_budgets.get(actor_id)
+        if component is None:
+            component = ActionBudgetComponent()
+            self._fallback_budgets[actor_id] = component
+        return component
+
+
+def _ensure_intent(intent_obj: Any | None, payload: Any) -> ActionIntent:
+    if isinstance(intent_obj, ActionIntent):
+        return intent_obj
+    if isinstance(payload, Mapping):
+        return ActionIntent.from_dict(payload)
+    if isinstance(payload, ActionIntent):
+        return payload
+    raise TypeError("Intent payload is neither mapping nor ActionIntent")
+
+
+def _is_reactionable(action_def: ActionDef) -> bool:
+    tags = {tag.lower() for tag in action_def.tags}
+    if "reactionable" in tags:
+        return True
+    if "attack" in tags:
+        return True
+    return False
+
+
+__all__ = ["ActionScheduler", "ReservationResult"]
+

--- a/core/actions/validation.py
+++ b/core/actions/validation.py
@@ -1,0 +1,359 @@
+"""Validation layer turning submitted intents into executable actions.
+
+This module is the single entry point between the declarative intent layer and
+the execution pipeline.  It validates the incoming :class:`ActionIntent`
+instances against lightweight rules (resources, status flags, targeting, ...)
+without mutating any game state.  When bound to an event bus it reacts to
+``INTENT_SUBMITTED`` events and publishes either ``INTENT_VALIDATED`` or
+``INTENT_REJECTED`` accordingly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional, Protocol, Tuple
+
+from core.actions.catalog import ACTION_CATALOG, ActionDef
+from core.actions.intent import ActionIntent, CostSpec
+from core.events import topics
+
+
+class EventBusLike(Protocol):
+    """Minimal protocol required to interact with the project event bus."""
+
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        ...
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Container returned by :func:`validate_intent`."""
+
+    ok: bool
+    reason: Optional[str]
+    intent: ActionIntent
+
+
+def validate_intent(
+    intent: ActionIntent | Mapping[str, Any],
+    ecs: Any,
+    rules_ctx: Any,
+) -> Tuple[bool, Optional[str], ActionIntent]:
+    """Validate an :class:`ActionIntent` without mutating any game state.
+
+    Parameters
+    ----------
+    intent:
+        The incoming intent or its serialised representation.
+    ecs:
+        ECS façade used for lightweight queries (component lookups, entity
+        resolution).  It is *not* mutated by this routine.
+    rules_ctx:
+        Rules helper providing convenience accessors (movement budget,
+        ownership, cooldowns, ...).
+    """
+
+    normalised = _coerce_intent(intent)
+    action_def = ACTION_CATALOG.get(normalised.action_id)
+    if action_def is None:
+        return False, "unknown_action", normalised
+
+    reason = _verify_actor(normalised, ecs, rules_ctx)
+    if reason is not None:
+        return False, reason, normalised
+
+    reason = _verify_action_state(normalised, action_def, ecs, rules_ctx)
+    if reason is not None:
+        return False, reason, normalised
+
+    reason = _verify_costs(normalised, action_def, ecs, rules_ctx)
+    if reason is not None:
+        return False, reason, normalised
+
+    reason = _verify_targets(normalised, action_def, ecs, rules_ctx)
+    if reason is not None:
+        return False, reason, normalised
+
+    reason = _verify_cooldowns(normalised, action_def, rules_ctx)
+    if reason is not None:
+        return False, reason, normalised
+
+    return True, None, normalised
+
+
+class IntentValidator:
+    """Event-driven wrapper around :func:`validate_intent`."""
+
+    def __init__(self, ecs: Any, rules_ctx: Any) -> None:
+        self._ecs = ecs
+        self._rules = rules_ctx
+        self._bus: EventBusLike | None = None
+
+    def bind(self, bus: EventBusLike) -> None:
+        """Subscribe to the intent submission topic on ``bus``."""
+
+        self._bus = bus
+        bus.subscribe(topics.INTENT_SUBMITTED, self._handle_intent_submitted)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _handle_intent_submitted(self, *, intent: Any, **extra: Any) -> None:
+        if self._bus is None:
+            return
+
+        ok, reason, normalised = validate_intent(intent, self._ecs, self._rules)
+        payload = {
+            "intent": normalised.to_dict(),
+            "intent_obj": normalised,
+        }
+        payload.update(extra)
+
+        if ok:
+            payload.setdefault("reason", None)
+            self._bus.publish(topics.INTENT_VALIDATED, **payload)
+        else:
+            payload["reason"] = reason
+            self._bus.publish(topics.INTENT_REJECTED, **payload)
+
+
+# ----------------------------------------------------------------------
+# Validation helpers
+# ----------------------------------------------------------------------
+
+
+def _coerce_intent(intent: ActionIntent | Mapping[str, Any]) -> ActionIntent:
+    if isinstance(intent, ActionIntent):
+        return intent
+    if isinstance(intent, Mapping):
+        return ActionIntent.from_dict(intent)
+    raise TypeError("intent must be an ActionIntent or mapping payload")
+
+
+def _verify_actor(intent: ActionIntent, ecs: Any, rules_ctx: Any) -> Optional[str]:
+    actor_id = intent.actor_id
+    if not actor_id:
+        return "missing_actor"
+
+    if not _entity_exists(actor_id, ecs):
+        return "unknown_actor"
+
+    owner = intent.source_player_id
+    if owner:
+        checker = getattr(rules_ctx, "is_actor_controlled_by", None)
+        if callable(checker) and not checker(actor_id, owner):
+            return "unauthorised_actor"
+
+    forbidden_state = getattr(rules_ctx, "is_action_locked", None)
+    if callable(forbidden_state) and forbidden_state(actor_id):
+        return "actor_locked"
+
+    return None
+
+
+def _verify_action_state(
+    intent: ActionIntent,
+    action_def: ActionDef,
+    ecs: Any,
+    rules_ctx: Any,
+) -> Optional[str]:
+    checker = getattr(rules_ctx, "is_action_allowed", None)
+    if callable(checker):
+        allowed = checker(intent.actor_id, action_def.id, intent=intent, ecs=ecs)
+        if allowed is False:
+            return "action_forbidden"
+
+    blockers = getattr(rules_ctx, "get_blocked_actions", None)
+    if callable(blockers):
+        blocked = blockers(intent.actor_id)
+        try:
+            if blocked and action_def.id in set(blocked):
+                return "action_blocked"
+        except TypeError:
+            pass
+
+    for prereq in action_def.prereqs:
+        if isinstance(prereq, str):
+            predicate = getattr(rules_ctx, prereq, None)
+            if callable(predicate) and not predicate(intent.actor_id, intent=intent):
+                return f"prereq_failed:{prereq}"
+            continue
+
+        if callable(prereq):
+            try:
+                result = prereq(actor_id=intent.actor_id, intent=intent, ecs=ecs, rules=rules_ctx)
+            except TypeError:
+                result = prereq(intent.actor_id)
+            if not result:
+                name = getattr(prereq, "__name__", "prereq")
+                return f"prereq_failed:{name}"
+
+    return None
+
+
+def _verify_costs(
+    intent: ActionIntent,
+    action_def: ActionDef,
+    ecs: Any,
+    rules_ctx: Any,
+) -> Optional[str]:
+    costs = action_def.costs
+    if not isinstance(costs, CostSpec):
+        return None
+
+    for resource, required in costs.to_dict().items():
+        if required <= 0:
+            continue
+        available = _resolve_resource(intent.actor_id, resource, ecs, rules_ctx)
+        if available is None:
+            continue
+        if available < required:
+            return f"insufficient_{resource}"
+    return None
+
+
+def _verify_targets(
+    intent: ActionIntent,
+    action_def: ActionDef,
+    ecs: Any,
+    rules_ctx: Any,
+) -> Optional[str]:
+    expected = tuple(action_def.targeting or ())
+    provided = intent.targets
+
+    if not expected:
+        if provided:
+            return "unexpected_targets"
+        return None
+
+    allowed_kinds: set[str] = set()
+    required_count = 0
+    for descriptor in expected:
+        if isinstance(descriptor, Mapping):
+            kind = str(descriptor.get("kind", descriptor.get("type", ""))).lower()
+        else:
+            kind = str(descriptor).lower()
+        if not kind:
+            continue
+        allowed_kinds.add(kind)
+        required_count += 1
+
+    if required_count and len(provided) < required_count:
+        return "missing_targets"
+
+    for target in provided:
+        if target.kind.lower() not in allowed_kinds:
+            return "invalid_target_kind"
+        if target.kind == "entity":
+            if not target.reference:
+                return "invalid_target_reference"
+            if not _entity_exists(target.reference, ecs):
+                return "invalid_target_reference"
+
+    validator = getattr(rules_ctx, "validate_targets", None)
+    if callable(validator):
+        try:
+            verdict = validator(intent, action_def, ecs=ecs)
+        except TypeError:
+            verdict = validator(intent, action_def)
+        if isinstance(verdict, tuple):
+            ok, reason = verdict
+            if not ok:
+                return reason or "invalid_targets"
+        elif verdict is False:
+            return "invalid_targets"
+
+    return None
+
+
+def _verify_cooldowns(
+    intent: ActionIntent,
+    action_def: ActionDef,
+    rules_ctx: Any,
+) -> Optional[str]:
+    checker = getattr(rules_ctx, "is_on_cooldown", None)
+    if callable(checker):
+        on_cooldown = checker(intent.actor_id, action_def.id)
+        if on_cooldown:
+            return "on_cooldown"
+
+    getter = getattr(rules_ctx, "get_cooldown", None)
+    if callable(getter):
+        cooldown_value = getter(intent.actor_id, action_def.id)
+        if cooldown_value:
+            try:
+                if int(cooldown_value) > 0:
+                    return "on_cooldown"
+            except (TypeError, ValueError):
+                pass
+
+    return None
+
+
+def _entity_exists(entity_id: str, ecs: Any) -> bool:
+    if ecs is None:
+        return True
+
+    resolver = getattr(ecs, "resolve_entity", None)
+    if callable(resolver):
+        if resolver(entity_id) is not None:
+            return True
+
+    has_entity = getattr(ecs, "has_entity", None)
+    if callable(has_entity):
+        try:
+            if has_entity(entity_id):
+                return True
+        except TypeError:
+            pass
+
+    entities = getattr(ecs, "entities", None)
+    if isinstance(entities, Mapping) and entity_id in entities:
+        return True
+
+    roster = getattr(ecs, "roster", None)
+    if isinstance(roster, Mapping) and entity_id in roster:
+        return True
+
+    return False
+
+
+def _resolve_resource(
+    actor_id: str,
+    resource: str,
+    ecs: Any,
+    rules_ctx: Any,
+) -> Optional[int]:
+    getter_names = (
+        f"get_{resource}",
+        f"get_{resource}_points",
+        f"get_{resource}_pool",
+        f"get_{resource}_remaining",
+    )
+    for name in getter_names:
+        accessor = getattr(rules_ctx, name, None)
+        if callable(accessor):
+            value = accessor(actor_id)
+            if value is not None:
+                return int(value)
+
+    mapping = getattr(ecs, resource, None)
+    if isinstance(mapping, Mapping):
+        value = mapping.get(actor_id)
+        if value is not None:
+            return int(value)
+
+    getter = getattr(ecs, f"get_{resource}", None)
+    if callable(getter):
+        value = getter(actor_id)
+        if value is not None:
+            return int(value)
+
+    return None
+
+
+__all__ = ["validate_intent", "IntentValidator", "ValidationResult"]
+

--- a/core/reactions/manager.py
+++ b/core/reactions/manager.py
@@ -1,0 +1,257 @@
+"""Reaction window orchestration."""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Protocol
+
+from core.actions.catalog import ACTION_CATALOG, ActionDef
+from core.actions.intent import ActionIntent, TargetSpec
+from core.events import topics
+
+
+class EventBusLike(Protocol):
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        ...
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        ...
+
+
+@dataclass
+class ReactionOption:
+    action_id: str
+    name: str
+    speed: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "id": self.action_id,
+            "name": self.name,
+            "reaction_speed": self.speed,
+            "payload": dict(self.payload),
+        }
+
+
+@dataclass
+class PendingWindow:
+    window_id: str
+    defender_id: str
+    action_payload: Dict[str, Any]
+    options: List[ReactionOption]
+    resolved: bool = False
+    selection: Optional[Mapping[str, Any]] = None
+
+
+@dataclass
+class PendingAction:
+    action_payload: Dict[str, Any]
+    windows: Dict[str, PendingWindow]
+
+    def all_resolved(self) -> bool:
+        return all(window.resolved for window in self.windows.values())
+
+
+class ReactionManager:
+    """Manage reaction windows and resume action execution once done."""
+
+    def __init__(self, rules_ctx: Any) -> None:
+        self._rules = rules_ctx
+        self._bus: EventBusLike | None = None
+        self._pending_actions: Dict[str, PendingAction] = {}
+        self._counter = itertools.count(1)
+
+    def bind(self, bus: EventBusLike) -> None:
+        self._bus = bus
+        bus.subscribe(topics.PERFORM_ACTION, self._handle_perform_action)
+        bus.subscribe(topics.REACTION_DECLARED, self._handle_reaction_declared)
+
+    # ------------------------------------------------------------------
+    def _handle_perform_action(self, *, await_reactions: bool | None = None, intent: Any, intent_obj: Any | None = None, **payload: Any) -> None:
+        if not await_reactions:
+            return
+        if self._bus is None:
+            return
+
+        normalised = _ensure_intent(intent_obj, intent)
+        action_def = ACTION_CATALOG.get(normalised.action_id)
+        if action_def is None:
+            return
+
+        action_payload = dict(payload)
+        action_payload.update({
+            "intent": normalised.to_dict(),
+            "intent_obj": normalised,
+            "action_id": normalised.action_id,
+            "actor_id": normalised.actor_id,
+        })
+        action_id = action_payload.get("reservation_id") or normalised.client_tx_id or f"{normalised.actor_id}:{normalised.action_id}:{next(self._counter)}"
+
+        defenders = _collect_defenders(normalised.targets)
+        if not defenders:
+            self._resume_action(action_id, action_payload, reactions=[])
+            return
+
+        options = list(self._gather_reaction_options(action_def, normalised))
+        if not options:
+            self._resume_action(action_id, action_payload, reactions=[])
+            return
+
+        windows: Dict[str, PendingWindow] = {}
+        for defender_id in defenders:
+            window_id = f"{action_id}:{defender_id}"
+            window = PendingWindow(
+                window_id=window_id,
+                defender_id=defender_id,
+                action_payload=action_payload,
+                options=list(options),
+            )
+            windows[window_id] = window
+            self._publish_window(window, normalised, action_def)
+
+        self._pending_actions[action_id] = PendingAction(action_payload=action_payload, windows=windows)
+
+    def _handle_reaction_declared(self, *, actor_id: str, reaction: Any = None, passed: bool = False, window_id: Optional[str] = None, **_: Any) -> None:
+        if self._bus is None:
+            return
+
+        pending, window = self._locate_window(actor_id, window_id)
+        if pending is None or window is None:
+            return
+
+        window.resolved = True
+        if not passed and reaction:
+            window.selection = reaction
+
+        if not pending.all_resolved():
+            return
+
+        reactions = []
+        for wnd in pending.windows.values():
+            if wnd.selection:
+                reactions.append(dict(wnd.selection))
+
+        self._finalise_reactions(pending, reactions)
+
+    # ------------------------------------------------------------------
+    def _publish_window(self, window: PendingWindow, intent: ActionIntent, action_def: ActionDef) -> None:
+        if self._bus is None:
+            return
+
+        context = {
+            "attacker": intent.actor_id,
+            "defender": window.defender_id,
+            "action_id": intent.action_id,
+            "action_name": action_def.name,
+        }
+        options_payload = [option.to_payload() for option in window.options]
+        self._bus.publish(
+            topics.REACTION_WINDOW_OPENED,
+            actor_id=window.defender_id,
+            options=options_payload,
+            window_id=window.window_id,
+            context=context,
+        )
+
+    def _locate_window(self, actor_id: str, window_id: Optional[str]) -> tuple[Optional[PendingAction], Optional[PendingWindow]]:
+        if window_id:
+            action_id = window_id.split(":", 2)[0]
+            pending = self._pending_actions.get(action_id)
+            if not pending:
+                return None, None
+            window = pending.windows.get(window_id)
+            return pending, window
+
+        for action_id, pending in self._pending_actions.items():
+            for window in pending.windows.values():
+                if window.defender_id == actor_id and not window.resolved:
+                    return pending, window
+        return None, None
+
+    def _finalise_reactions(self, pending: PendingAction, reactions: List[Mapping[str, Any]]) -> None:
+        if self._bus is None:
+            return
+
+        action_id = pending.action_payload.get("reservation_id") or pending.action_payload.get("client_tx_id")
+        sorted_reactions = sorted(
+            reactions,
+            key=lambda entry: _reaction_priority(entry.get("reaction_speed")),
+        )
+
+        self._bus.publish(
+            topics.REACTION_RESOLVED,
+            action_id=pending.action_payload.get("action_id"),
+            actor_id=pending.action_payload.get("actor_id"),
+            reactions=sorted_reactions,
+            context=pending.action_payload.get("intent"),
+        )
+
+        self._resume_action(action_id or "pending", pending.action_payload, sorted_reactions)
+
+    def _resume_action(self, action_id: str, payload: Dict[str, Any], reactions: List[Mapping[str, Any]]) -> None:
+        if self._bus is None:
+            return
+
+        payload = dict(payload)
+        payload.update({
+            "await_reactions": False,
+            "reactions_resolved": True,
+            "reaction_results": reactions,
+        })
+        self._bus.publish(topics.PERFORM_ACTION, **payload)
+        self._pending_actions.pop(action_id, None)
+
+    def _gather_reaction_options(self, action_def: ActionDef, intent: ActionIntent) -> Iterable[ReactionOption]:
+        provider = getattr(self._rules, "iter_reaction_options", None)
+        if callable(provider):
+            yield from (
+                ReactionOption(
+                    action_id=str(option.get("id")),
+                    name=str(option.get("name", option.get("id", "reaction"))),
+                    speed=str(option.get("reaction_speed", "normal")),
+                    payload=option,
+                )
+                for option in provider(action_def, intent)
+                if isinstance(option, Mapping)
+            )
+            return
+
+        for definition in ACTION_CATALOG.values():
+            tags = {tag.lower() for tag in definition.tags}
+            if "reaction" not in tags:
+                continue
+            yield ReactionOption(
+                action_id=definition.id,
+                name=definition.name,
+                speed=definition.reaction_speed or "normal",
+                payload={"action_id": definition.id},
+            )
+
+
+def _ensure_intent(intent_obj: Any | None, payload: Any) -> ActionIntent:
+    if isinstance(intent_obj, ActionIntent):
+        return intent_obj
+    if isinstance(payload, ActionIntent):
+        return payload
+    if isinstance(payload, Mapping):
+        return ActionIntent.from_dict(payload)
+    raise TypeError("Intent payload is neither mapping nor ActionIntent")
+
+
+def _collect_defenders(targets: Iterable[TargetSpec]) -> List[str]:
+    defenders: List[str] = []
+    for target in targets:
+        if target.kind == "entity" and target.reference:
+            defenders.append(target.reference)
+    return defenders
+
+
+def _reaction_priority(speed: Any) -> int:
+    order = {"fast": 0, "normal": 1, "slow": 2}
+    return order.get(str(speed).lower(), 1)
+
+
+__all__ = ["ReactionManager"]
+

--- a/ecs/components/action_budget.py
+++ b/ecs/components/action_budget.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Mapping, MutableMapping, Optional, Set
+
+
+class ActionBudgetComponent:
+    """Track reserved action resources for an entity."""
+
+    def __init__(
+        self,
+        *,
+        reserved: Optional[Mapping[str, int]] = None,
+        pending: Optional[Mapping[str, int]] = None,
+        transactions: Optional[Set[str]] = None,
+    ) -> None:
+        self.reserved: MutableMapping[str, int] = dict(reserved or {})
+        self.pending: MutableMapping[str, int] = dict(pending or {})
+        self._transactions: Set[str] = set(transactions or set())
+
+    def reserve(self, costs: Mapping[str, int], *, transaction_id: Optional[str] = None) -> None:
+        """Record ``costs`` as pending for ``transaction_id`` if new."""
+
+        if transaction_id and transaction_id in self._transactions:
+            return
+
+        for resource, amount in costs.items():
+            value = int(amount)
+            if value <= 0:
+                continue
+            self.pending[resource] = self.pending.get(resource, 0) + value
+
+        if transaction_id:
+            self._transactions.add(transaction_id)
+
+    def commit(self, transaction_id: Optional[str] = None) -> None:
+        """Move pending resources to the reserved pool."""
+
+        for resource, value in list(self.pending.items()):
+            self.reserved[resource] = self.reserved.get(resource, 0) + value
+        self.pending.clear()
+        if transaction_id and transaction_id in self._transactions:
+            self._transactions.remove(transaction_id)
+
+    def clear(self) -> None:
+        """Reset all bookkeeping data."""
+
+        self.reserved.clear()
+        self.pending.clear()
+        self._transactions.clear()
+
+
+__all__ = ["ActionBudgetComponent"]
+

--- a/tests/unit/actions/test_performers.py
+++ b/tests/unit/actions/test_performers.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from core.actions.intent import ActionIntent, TargetSpec
+from core.actions.performers import ActionPerformer
+from core.events import topics
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.subscriptions: dict[str, list[Callable[..., None]]] = {}
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        self.subscriptions.setdefault(topic, []).append(handler)
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        self.published.append((topic, dict(payload)))
+        for handler in list(self.subscriptions.get(topic, [])):
+            handler(**payload)
+
+
+class StubMovementSystem:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[int, int]]] = []
+
+    def move(self, actor_id: str, dest: tuple[int, int], max_steps: int | None = None) -> bool:
+        self.calls.append((actor_id, dest))
+        return True
+
+
+class StubRules:
+    def __init__(self) -> None:
+        self.movement_system = StubMovementSystem()
+
+    def resolve_attack(self, actor_id: str, target_id: str, **_: Any) -> dict[str, Any]:
+        return {"hit": True, "damage": 2, "target": target_id}
+
+
+def test_performer_executes_move_action() -> None:
+    rules = StubRules()
+    performer = ActionPerformer(rules)
+    bus = DummyEventBus()
+    performer.bind(bus)
+
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="move",
+        targets=(TargetSpec.tile((2, 3)),),
+    )
+
+    bus.publish(topics.PERFORM_ACTION, intent=intent.to_dict(), intent_obj=intent, await_reactions=False)
+
+    events = [topic for topic, _ in bus.published]
+    assert topics.ACTION_RESOLVED in events
+    assert rules.movement_system.calls == [("hero", (2, 3))]
+
+
+def test_performer_waits_for_reactions() -> None:
+    rules = StubRules()
+    performer = ActionPerformer(rules)
+    bus = DummyEventBus()
+    performer.bind(bus)
+
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="attack_melee",
+        targets=(TargetSpec.entity("ghoul"),),
+    )
+
+    bus.publish(
+        topics.PERFORM_ACTION,
+        intent=intent.to_dict(),
+        intent_obj=intent,
+        await_reactions=True,
+        reactions_resolved=False,
+    )
+
+    assert all(topic != topics.ACTION_RESOLVED for topic, _ in bus.published)
+

--- a/tests/unit/actions/test_reaction_manager.py
+++ b/tests/unit/actions/test_reaction_manager.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from core.actions.intent import ActionIntent, TargetSpec
+from core.actions.performers import ActionPerformer
+from core.events import topics
+from core.reactions.manager import ReactionManager
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.subscriptions: dict[str, list[Callable[..., None]]] = {}
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        self.subscriptions.setdefault(topic, []).append(handler)
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        self.published.append((topic, dict(payload)))
+        for handler in list(self.subscriptions.get(topic, [])):
+            handler(**payload)
+
+
+class StubRules:
+    def __init__(self) -> None:
+        self._reaction_options = [
+            {"id": "defend_dodge", "name": "Dodge", "reaction_speed": "fast"}
+        ]
+
+    def iter_reaction_options(self, action_def: Any, intent: ActionIntent):
+        return list(self._reaction_options)
+
+    def resolve_attack(self, actor_id: str, target_id: str, **_: Any) -> dict[str, Any]:
+        return {"hit": True, "damage": 3, "target": target_id}
+
+    @property
+    def movement_system(self) -> None:  # pragma: no cover - not used here
+        return None
+
+
+def test_reaction_manager_opens_window_and_resumes_flow() -> None:
+    bus = DummyEventBus()
+    rules = StubRules()
+    reactions = ReactionManager(rules)
+    performer = ActionPerformer(rules)
+    reactions.bind(bus)
+    performer.bind(bus)
+
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="attack_melee",
+        targets=(TargetSpec.entity("ghoul"),),
+    )
+
+    bus.publish(
+        topics.PERFORM_ACTION,
+        intent=intent.to_dict(),
+        intent_obj=intent,
+        await_reactions=True,
+        reservation_id="txn-1",
+    )
+
+    window_events = [payload for topic, payload in bus.published if topic == topics.REACTION_WINDOW_OPENED]
+    assert window_events, "reaction window should be opened"
+    window_payload = window_events[0]
+    window_id = window_payload["window_id"]
+
+    bus.publish(
+        topics.REACTION_DECLARED,
+        actor_id="ghoul",
+        reaction={"id": "defend_dodge", "reaction_speed": "fast"},
+        passed=False,
+        window_id=window_id,
+    )
+
+    perform_events = [payload for topic, payload in bus.published if topic == topics.PERFORM_ACTION]
+    assert any(payload.get("reactions_resolved") for payload in perform_events)
+
+    resolved_events = [payload for topic, payload in bus.published if topic == topics.ACTION_RESOLVED]
+    assert resolved_events, "action should eventually resolve"
+

--- a/tests/unit/actions/test_scheduler.py
+++ b/tests/unit/actions/test_scheduler.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from core.actions.intent import ActionIntent, TargetSpec
+from core.actions.scheduler import ActionScheduler
+from core.events import topics
+from ecs.components.action_budget import ActionBudgetComponent
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.subscriptions: dict[str, list[Callable[..., None]]] = {}
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        self.subscriptions.setdefault(topic, []).append(handler)
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        self.published.append((topic, dict(payload)))
+        for handler in list(self.subscriptions.get(topic, [])):
+            handler(**payload)
+
+
+class StubECS:
+    def __init__(self) -> None:
+        self._entities = {"hero": 1}
+        self._components: dict[int, dict[type, Any]] = {}
+
+    def resolve_entity(self, entity_id: str) -> int | None:
+        return self._entities.get(entity_id)
+
+    def try_get_component(self, internal_id: int, component_type: type) -> Any | None:
+        return self._components.get(internal_id, {}).get(component_type)
+
+    def add_component(self, internal_id: int, component: Any) -> None:
+        self._components.setdefault(internal_id, {})[type(component)] = component
+
+
+def test_scheduler_reserves_and_dispatches() -> None:
+    ecs = StubECS()
+    bus = DummyEventBus()
+    scheduler = ActionScheduler(ecs)
+    scheduler.bind(bus)
+
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="attack_melee",
+        targets=(TargetSpec.entity("ghoul"),),
+    )
+
+    bus.publish(topics.INTENT_VALIDATED, intent=intent.to_dict(), intent_obj=intent)
+
+    events = [topic for topic, _ in bus.published]
+    assert topics.ACTION_ENQUEUED in events
+    assert events.count(topics.PERFORM_ACTION) == 1
+
+    internal_id = ecs.resolve_entity("hero")
+    assert internal_id is not None
+    component = ecs.try_get_component(internal_id, ActionBudgetComponent)
+    assert isinstance(component, ActionBudgetComponent)
+    assert component.pending.get("action_points") == 1
+

--- a/tests/unit/actions/test_validation_pipeline.py
+++ b/tests/unit/actions/test_validation_pipeline.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import pytest
+
+from core.actions.intent import ActionIntent, TargetSpec
+from core.actions.validation import IntentValidator, validate_intent
+from core.events import topics
+
+
+class StubECS:
+    def __init__(self) -> None:
+        self._entities = {"hero": 1, "ghoul": 2}
+
+    def resolve_entity(self, entity_id: str) -> int | None:
+        return self._entities.get(entity_id)
+
+
+class StubRules:
+    def get_movement_points(self, actor_id: str) -> int:
+        return 4
+
+    def get_action_points(self, actor_id: str) -> int:
+        return 2
+
+    def validate_targets(self, intent: ActionIntent, action_def: Any, **_: Any):
+        return True
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.subscriptions: dict[str, list[Callable[..., None]]] = {}
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    def subscribe(self, topic: str, handler: Callable[..., None]) -> None:
+        self.subscriptions.setdefault(topic, []).append(handler)
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        self.published.append((topic, dict(payload)))
+        for handler in list(self.subscriptions.get(topic, [])):
+            handler(**payload)
+
+
+def test_validate_intent_success() -> None:
+    ecs = StubECS()
+    rules = StubRules()
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="move",
+        targets=(TargetSpec.tile((1, 2)),),
+    )
+
+    ok, reason, normalised = validate_intent(intent, ecs, rules)
+
+    assert ok is True
+    assert reason is None
+    assert normalised == intent
+
+
+def test_validate_intent_rejects_insufficient_resources() -> None:
+    ecs = StubECS()
+
+    class NoPoints(StubRules):
+        def get_action_points(self, actor_id: str) -> int:
+            return 0
+
+    rules = NoPoints()
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="attack_melee",
+        targets=(TargetSpec.entity("ghoul"),),
+    )
+
+    ok, reason, _ = validate_intent(intent, ecs, rules)
+
+    assert ok is False
+    assert reason == "insufficient_action_points"
+
+
+def test_validate_intent_rejects_bad_target_kind() -> None:
+    ecs = StubECS()
+    rules = StubRules()
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="attack_melee",
+        targets=(TargetSpec.tile((0, 0)),),
+    )
+
+    ok, reason, _ = validate_intent(intent, ecs, rules)
+
+    assert ok is False
+    assert reason == "invalid_target_kind"
+
+
+def test_intent_validator_publishes_events() -> None:
+    ecs = StubECS()
+    rules = StubRules()
+    validator = IntentValidator(ecs, rules)
+    bus = DummyEventBus()
+    validator.bind(bus)
+
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="move",
+        targets=(TargetSpec.tile((3, 4)),),
+    )
+
+    bus.publish(topics.INTENT_SUBMITTED, intent=intent.to_dict())
+
+    events = [topic for topic, _ in bus.published]
+    assert topics.INTENT_VALIDATED in events
+


### PR DESCRIPTION
## Summary
- add an intent validation layer with an event-driven validator that emits accepted and rejected intents
- introduce an action scheduler with an action budget component to reserve costs and trigger execution
- wire new performers and reaction manager to execute actions, open reaction windows, and resume flow after responses
- provide focused unit tests covering validation, scheduling, performers, and reaction orchestration

## Testing
- pytest tests/unit/actions -q

------
https://chatgpt.com/codex/tasks/task_e_68e04f96fee4832d922ae795d66c3673