### PR TITLE
Add UI bridge port and read-only query surfaces

### DIFF
--- a/core/characters/__init__.py
+++ b/core/characters/__init__.py
@@ -1,0 +1,5 @@
+"""Character query surfaces for UI and rule modules."""
+
+from .query import get_character_summary
+
+__all__ = ["get_character_summary"]

--- a/core/characters/query.py
+++ b/core/characters/query.py
@@ -75,16 +75,20 @@ def get_character_summary(actor_id: str, ecs: Any) -> dict[str, Any]:
         tracker = tracker_components[0] if tracker_components else None
 
     if tracker is not None:
-        active_states_attr = getattr(tracker, "active_states", None)
-        tracker_states: Any = ()
+        for attr_name in ("active_states", "dynamic_states"):
+            tracker_states_attr = getattr(tracker, attr_name, None)
+            tracker_states: Any = ()
 
-        if callable(active_states_attr):
-            tracker_states = active_states_attr()
-        elif active_states_attr is not None:
-            tracker_states = active_states_attr
+            if callable(tracker_states_attr):
+                try:
+                    tracker_states = tracker_states_attr()
+                except TypeError:  # pragma: no cover - defensive guard
+                    tracker_states = ()
+            elif tracker_states_attr is not None:
+                tracker_states = tracker_states_attr
 
-        for state in _iterate_state_values(tracker_states):
-            states.add(str(state))
+            for state in _iterate_state_values(tracker_states):
+                states.add(str(state))
 
     summary["states"] = tuple(sorted(states))
 

--- a/core/characters/query.py
+++ b/core/characters/query.py
@@ -6,8 +6,21 @@ from typing import Any, Mapping, Sequence
 
 
 def get_character_summary(actor_id: str, ecs: Any) -> dict[str, Any]:
-    """Return a read-only summary of character data relevant to the UI layer."""
+    """
+    Return a read-only summary of character data relevant to the UI layer.
 
+    Returns:
+        dict: A dictionary with the following structure:
+            - actor_id (str): The unique identifier for the character.
+            - name (str or None): The character's name, or None if unavailable.
+            - clan (str or None): The character's clan, or None if unavailable.
+            - attributes (dict): A mapping of attribute names to their values (may be empty).
+            - skills (dict): A mapping of skill names to their values (may be empty).
+            - disciplines (tuple): A tuple of discipline IDs (as strings), possibly empty.
+            - states (tuple): A tuple of state names (as strings), possibly empty.
+
+    All values are read-only and suitable for display in the UI layer.
+    """
     manager = _locate_ecs_manager(ecs)
     summary = {
         "actor_id": actor_id,

--- a/core/characters/query.py
+++ b/core/characters/query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 
 def get_character_summary(actor_id: str, ecs: Any) -> dict[str, Any]:
@@ -42,10 +42,14 @@ def get_character_summary(actor_id: str, ecs: Any) -> dict[str, Any]:
     traits = _ensure_mapping(getattr(character, "traits", {}))
     summary["attributes"] = _clone_mapping(traits.get("Attributes", {}))
     summary["skills"] = _clone_mapping(
-        traits.get("Abilities")
-        or traits.get("Skills")
-        or traits.get("Competences")
-        or {}
+        _select_first_present_mapping(
+            traits,
+            (
+                "Abilities",
+                "Skills",
+                "Competences",
+            ),
+        )
     )
 
     discipline_ids: set[str] = set()
@@ -113,6 +117,17 @@ def _locate_ecs_manager(ecs: Any) -> Any:
 def _ensure_mapping(value: Any) -> Mapping[str, Any]:
     if isinstance(value, Mapping):
         return value
+    return {}
+
+
+def _select_first_present_mapping(
+    source: Mapping[str, Any], keys: Sequence[str]
+) -> Mapping[str, Any]:
+    for key in keys:
+        if key in source:
+            candidate = source[key]
+            if isinstance(candidate, Mapping):
+                return candidate
     return {}
 
 

--- a/core/characters/query.py
+++ b/core/characters/query.py
@@ -1,0 +1,124 @@
+"""High-level character information queries."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def get_character_summary(actor_id: str, ecs: Any) -> dict[str, Any]:
+    """Return a read-only summary of character data relevant to the UI layer."""
+
+    manager = _locate_ecs_manager(ecs)
+    summary = {
+        "actor_id": actor_id,
+        "name": None,
+        "clan": None,
+        "attributes": {},
+        "skills": {},
+        "disciplines": (),
+        "states": (),
+    }
+
+    if manager is None:
+        return summary
+
+    try:
+        from ecs.components.character_ref import CharacterRefComponent
+    except ImportError:  # pragma: no cover - optional dependency guard
+        return summary
+
+    components = manager.get_components_for_entity(actor_id, CharacterRefComponent)
+    if not components:
+        return summary
+
+    character_component = components[0]
+    character = getattr(character_component, "character", None)
+    if character is None:
+        return summary
+
+    summary["name"] = getattr(character, "name", None)
+    summary["clan"] = getattr(character, "clan", None)
+
+    traits = _ensure_mapping(getattr(character, "traits", {}))
+    summary["attributes"] = _clone_mapping(traits.get("Attributes", {}))
+    summary["skills"] = _clone_mapping(
+        traits.get("Abilities")
+        or traits.get("Skills")
+        or traits.get("Competences")
+        or {}
+    )
+
+    discipline_ids: set[str] = set()
+    discipline_traits = traits.get("Disciplines", {})
+    if isinstance(discipline_traits, Mapping):
+        for key in discipline_traits.keys():
+            discipline_ids.add(str(key))
+
+    clan_disciplines = getattr(character, "clan_disciplines", None)
+    if isinstance(clan_disciplines, Mapping):
+        for key in clan_disciplines.keys():
+            discipline_ids.add(str(key))
+
+    summary["disciplines"] = tuple(sorted(discipline_ids))
+
+    states: set[str] = set()
+    char_states = getattr(character, "states", None)
+    if isinstance(char_states, set):
+        states.update(str(state) for state in char_states)
+
+    try:
+        from ecs.components.condition_tracker import ConditionTrackerComponent
+    except ImportError:  # pragma: no cover - optional dependency guard
+        tracker = None
+    else:
+        tracker_components = manager.get_components_for_entity(actor_id, ConditionTrackerComponent)
+        tracker = tracker_components[0] if tracker_components else None
+
+    if tracker is not None and hasattr(tracker, "active_states"):
+        try:
+            tracker_states = tracker.active_states()
+        except TypeError:  # pragma: no cover - defensive guard
+            tracker_states = set()
+        for state in tracker_states:
+            states.add(str(state))
+
+    summary["states"] = tuple(sorted(states))
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _locate_ecs_manager(ecs: Any) -> Any:
+    if hasattr(ecs, "resolve_entity"):
+        return ecs
+
+    candidate = getattr(ecs, "ecs_manager", None)
+    if candidate is not None and hasattr(candidate, "resolve_entity"):
+        return candidate
+
+    return None
+
+
+def _ensure_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _clone_mapping(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        return {}
+
+    result: dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(value, Mapping):
+            result[str(key)] = _clone_mapping(value)
+        else:
+            result[str(key)] = value
+    return result
+
+
+__all__ = ["get_character_summary"]

--- a/core/events/topics.py
+++ b/core/events/topics.py
@@ -18,3 +18,5 @@ REACTION_RESOLVED = "reaction_resolved"
 
 END_TURN = "end_turn"
 
+INVENTORY_QUERIED = "inventory_queried"
+

--- a/core/inventory/__init__.py
+++ b/core/inventory/__init__.py
@@ -1,0 +1,5 @@
+"""Inventory query surfaces exposed to gameplay rules."""
+
+from .query import get_equipped, ItemRef
+
+__all__ = ["get_equipped", "ItemRef"]

--- a/core/inventory/query.py
+++ b/core/inventory/query.py
@@ -56,30 +56,33 @@ def get_equipped(actor_id: str, ecs: Any) -> list[ItemRef]:
 
 def _collect_equipment_items(equipment: Any) -> list[ItemRef]:
     items: list[ItemRef] = []
-    seen: set[int] = set()
+    seen_identities: set[int] = set()
 
-    def _append(item: Any) -> None:
+    def _append(item: Any, *, dedupe: bool) -> None:
         if item is None:
             return
-        identity = id(item)
-        if identity in seen:
-            return
-        seen.add(identity)
+
+        if dedupe:
+            identity = id(item)
+            if identity in seen_identities:
+                return
+            seen_identities.add(identity)
+
         items.append(item)
 
-    _append(getattr(equipment, "equipped_weapon", None))
+    _append(getattr(equipment, "equipped_weapon", None), dedupe=True)
 
     weapons = getattr(equipment, "weapons", {})
     if isinstance(weapons, dict):
         for weapon in weapons.values():
-            _append(weapon)
+            _append(weapon, dedupe=True)
 
-    _append(getattr(equipment, "armor", None))
+    _append(getattr(equipment, "armor", None), dedupe=True)
 
     other_items = getattr(equipment, "other_items", None)
     if isinstance(other_items, Sequence):
         for item in other_items:
-            _append(item)
+            _append(item, dedupe=False)
 
     return items
 

--- a/core/inventory/query.py
+++ b/core/inventory/query.py
@@ -73,10 +73,8 @@ def _collect_equipment_items(equipment: Any) -> list[ItemRef]:
     _append(getattr(equipment, "equipped_weapon", None), dedupe=True)
 
     weapons = getattr(equipment, "weapons", {})
-    if isinstance(weapons, dict):
-        for weapon in weapons.values():
-            _append(weapon, dedupe=True)
-
+    for weapon in weapons.values():
+        _append(weapon, dedupe=True)
     _append(getattr(equipment, "armor", None), dedupe=True)
 
     other_items = getattr(equipment, "other_items", None)

--- a/core/inventory/query.py
+++ b/core/inventory/query.py
@@ -1,0 +1,127 @@
+"""Read-only inventory query helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol, Sequence, TypeAlias
+
+from core.events import topics
+
+
+ItemRef: TypeAlias = Any
+
+
+class _EventBusLike(Protocol):
+    def publish(self, event_type: str, /, **payload: Any) -> None:
+        ...
+
+
+def get_equipped(actor_id: str, ecs: Any) -> list[ItemRef]:
+    """Return equipped item references for ``actor_id`` and emit an event.
+
+    The function inspects the ECS for an :class:`EquipmentComponent` tied to the
+    provided ``actor_id``.  It returns a list of item references (weapons, armor,
+    miscellaneous gear) without mutating any underlying state.  Regardless of the
+    outcome, an :data:`~core.events.topics.INVENTORY_QUERIED` event is published so
+    that UI bridges can mirror the same data surfaced to the CLI.
+    """
+
+    manager = _locate_ecs_manager(ecs)
+    if manager is None:
+        items: list[ItemRef] = []
+        _publish_inventory_event(actor_id, items, ecs)
+        return items
+
+    try:
+        from ecs.components.equipment import EquipmentComponent
+    except ImportError:  # pragma: no cover - optional dependency guard
+        items = []
+        _publish_inventory_event(actor_id, items, manager)
+        return items
+
+    components = manager.get_components_for_entity(actor_id, EquipmentComponent)
+    if not components:
+        items = []
+        _publish_inventory_event(actor_id, items, manager)
+        return items
+
+    equipment = components[0]
+    items = _collect_equipment_items(equipment)
+    _publish_inventory_event(actor_id, items, manager)
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _collect_equipment_items(equipment: Any) -> list[ItemRef]:
+    items: list[ItemRef] = []
+    seen: set[int] = set()
+
+    def _append(item: Any) -> None:
+        if item is None:
+            return
+        identity = id(item)
+        if identity in seen:
+            return
+        seen.add(identity)
+        items.append(item)
+
+    _append(getattr(equipment, "equipped_weapon", None))
+
+    weapons = getattr(equipment, "weapons", {})
+    if isinstance(weapons, dict):
+        for weapon in weapons.values():
+            _append(weapon)
+
+    _append(getattr(equipment, "armor", None))
+
+    other_items = getattr(equipment, "other_items", None)
+    if isinstance(other_items, Sequence):
+        for item in other_items:
+            _append(item)
+
+    return items
+
+
+def _publish_inventory_event(actor_id: str, items: Sequence[ItemRef], source: Any) -> None:
+    event_bus = _locate_event_bus(source)
+    if event_bus is None:
+        return
+
+    publish = getattr(event_bus, "publish", None)
+    if callable(publish):
+        publish(topics.INVENTORY_QUERIED, actor_id=actor_id, items=tuple(items))
+
+
+def _locate_ecs_manager(ecs: Any) -> Any:
+    if hasattr(ecs, "resolve_entity"):
+        return ecs
+
+    candidate = getattr(ecs, "ecs_manager", None)
+    if candidate is not None and hasattr(candidate, "resolve_entity"):
+        return candidate
+
+    return None
+
+
+def _locate_event_bus(source: Any) -> Optional[_EventBusLike]:
+    if source is None:
+        return None
+
+    event_bus = getattr(source, "event_bus", None)
+    if event_bus is not None:
+        return event_bus  # type: ignore[return-value]
+
+    if hasattr(source, "game_state"):
+        game_state = getattr(source, "game_state")
+        return _locate_event_bus(game_state)
+
+    if hasattr(source, "ecs_manager"):
+        manager = getattr(source, "ecs_manager")
+        return _locate_event_bus(manager)
+
+    return None
+
+
+__all__ = ["ItemRef", "get_equipped"]

--- a/tests/unit/test_query_surfaces.py
+++ b/tests/unit/test_query_surfaces.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.characters.query import get_character_summary
+from core.events import topics
+from core.inventory.query import get_equipped
+from ecs.components.character_ref import CharacterRefComponent
+from ecs.components.condition_tracker import ConditionTrackerComponent
+from ecs.components.entity_id import EntityIdComponent
+from ecs.components.equipment import EquipmentComponent
+from ecs.ecs_manager import ECSManager
+from entities.character import Character
+
+
+class RecordingBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def publish(self, event_type: str, /, **payload: Any) -> None:
+        self.events.append((event_type, dict(payload)))
+
+    def subscribe(self, *_: Any, **__: Any) -> None:  # pragma: no cover - compatibility
+        return
+
+
+class DummyWeapon:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.attack_traits = ("Attributes.Physical.Strength", "Abilities.Talents.Brawl")
+
+
+@pytest.fixture()
+def ecs_manager() -> ECSManager:
+    return ECSManager(event_bus=RecordingBus())
+
+
+def test_get_equipped_returns_items_and_emits_event(ecs_manager: ECSManager) -> None:
+    weapon = DummyWeapon("Sword")
+    equipment = EquipmentComponent()
+    equipment.weapons["melee"] = weapon
+    equipment.equipped_weapon = weapon
+    equipment.other_items.append("blood_potion")
+
+    ecs_manager.create_entity(EntityIdComponent("hero"), equipment)
+
+    items = get_equipped("hero", ecs_manager)
+
+    assert weapon in items
+    assert "blood_potion" in items
+
+    bus = ecs_manager.event_bus
+    assert bus is not None
+    assert (topics.INVENTORY_QUERIED, {"actor_id": "hero", "items": tuple(items)}) in bus.events
+
+
+def test_get_character_summary_merges_traits_and_states(ecs_manager: ECSManager) -> None:
+    traits = {
+        "Attributes": {"Physical": {"Strength": 3, "Dexterity": 2}},
+        "Abilities": {"Talents": {"Brawl": 4}},
+        "Disciplines": {"Celerity": 2},
+    }
+    character = Character(name="Test", clan="Brujah", traits=traits, base_traits=traits)
+    character.states.add("roused")
+
+    tracker = ConditionTrackerComponent()
+    tracker.dynamic_states.add("hidden")
+
+    ecs_manager.create_entity(
+        EntityIdComponent("hero"),
+        CharacterRefComponent(character),
+        tracker,
+    )
+
+    summary = get_character_summary("hero", ecs_manager)
+
+    assert summary["name"] == "Test"
+    assert summary["clan"] == "Brujah"
+    assert summary["attributes"]["Physical"]["Strength"] == 3
+    assert summary["skills"]["Talents"]["Brawl"] == 4
+    assert "Celerity" in summary["disciplines"]
+    assert "roused" in summary["states"]
+    assert "hidden" in summary["states"]

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,3 @@
+"""UI integration package for future front-ends."""
+
+__all__ = ["ports"]

--- a/ui/ports/__init__.py
+++ b/ui/ports/__init__.py
@@ -1,0 +1,5 @@
+"""Port definitions for connecting external UI layers."""
+
+from .ui_bridge_port import UIBridgePort
+
+__all__ = ["UIBridgePort"]

--- a/ui/ports/ui_bridge_port.py
+++ b/ui/ports/ui_bridge_port.py
@@ -1,0 +1,47 @@
+"""Protocols describing the passive UI bridge callbacks.
+
+The combat loop exposes a set of passive notifications intended for visual
+front-ends.  Concrete adapters (Arcade UI, network clients, etc.) can
+implement :class:`UIBridgePort` and bind themselves to the unified event
+stream without requiring refactors of the underlying systems.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol, Sequence
+
+
+class UIBridgePort(Protocol):
+    """Passive hooks exposed to optional UI bridges.
+
+    Implementations should avoid blocking the caller and favour enqueueing
+    any expensive rendering work.  Each callback mirrors a notification that
+    the hot-seat CLI already consumes, enabling feature parity while remaining
+    decoupled from concrete UI frameworks.
+    """
+
+    def show_action_options(
+        self,
+        actor_id: str,
+        options: Sequence[Mapping[str, Any]] | Sequence[Any],
+    ) -> None:
+        """Display the list of action options calculated for ``actor_id``."""
+
+    def highlight_targets(
+        self,
+        target_specs: Sequence[Mapping[str, Any]] | Sequence[Any],
+    ) -> None:
+        """Emphasise the currently highlighted targets on the UI surface."""
+
+    def show_reaction_prompt(
+        self,
+        context: Mapping[str, Any],
+        options: Sequence[Mapping[str, Any]] | Sequence[Any],
+    ) -> None:
+        """Inform the UI that a reaction window opened for the given context."""
+
+    def show_toast(self, event_summary: str) -> None:
+        """Render a lightweight notification summarising a recent event."""
+
+
+__all__ = ["UIBridgePort"]


### PR DESCRIPTION
## Summary
- define a passive UI bridge protocol to mirror hot-seat notifications for future Arcade integration
- expose read-only inventory and character query helpers, including a new INVENTORY_QUERIED event hook
- cover the new query surfaces with focused unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0fd65bf00832da0d17a5474bf665c