### PR TITLE
Add integration pipeline tests and diagnostics tooling

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -1,0 +1,66 @@
+# Input & Intent Event Flow
+
+This document summarises the canonical flow of combat intents as they travel
+through the event bus.  The same sequence is used by the hot-seat controller,
+AI shims that emulate player inputs, and any future UI front-ends.
+
+## Topics overview
+
+| Topic | Producer | Consumer(s) | Purpose |
+| ----- | -------- | ----------- | ------- |
+| `BEGIN_TURN` | Turn engine | Input controllers, UI | Signal that an actor becomes active. |
+| `REQUEST_ACTIONS` | Turn engine | `ActionSelector`, input controllers | Ask for action options for an actor. |
+| `ACTIONS_AVAILABLE` | `ActionSelector` | Controllers / UI | Provide declarative action options and valid targets. |
+| `INTENT_SUBMITTED` | Controllers | `IntentValidator` | Publish a declarative `ActionIntent`. |
+| `INTENT_VALIDATED` | `IntentValidator` | `ActionScheduler` | Confirm the intent is valid and ready to reserve costs. |
+| `ACTION_ENQUEUED` | `ActionScheduler` | Queue / metrics | Notify downstream systems that the action is queued. |
+| `PERFORM_ACTION` | `ActionScheduler`, `ReactionManager` | `ActionPerformer`, `ReactionManager` | Trigger execution (possibly pausing for reactions). |
+| `REACTION_WINDOW_OPENED` | `ReactionManager` | Controllers | Offer defenders a chance to respond. |
+| `REACTION_DECLARED` | Controllers | `ReactionManager` | Submit a chosen reaction or a pass. |
+| `REACTION_RESOLVED` | `ReactionManager` | `ActionPerformer`, UI | Inform that reactions are sorted and execution may resume. |
+| `ACTION_RESOLVED` | `ActionPerformer` | Turn engine, UI | Action results (damage, movement, etc.). |
+| `END_TURN` | Turn engine | Input controllers, UI | Active actor’s turn is finished. |
+
+## Sequence diagram
+
+```
+BEGIN_TURN
+   |
+   v
+REQUEST_ACTIONS ---> (ActionSelector)
+   |                    |
+   |                    v
+   |              ACTIONS_AVAILABLE
+   |                    |
+   |          +---------+----------+
+   |          |                    |
+   v          v                    v
+Controller publishes INTENT_SUBMITTED
+   |                    |
+   |              INTENT_VALIDATED
+   |                    |
+   v                    v
+ACTION_ENQUEUED ----> PERFORM_ACTION --> [optional] REACTION_WINDOW_OPENED
+                                       (if reactions)        |
+                                       <---------------------+
+                                       REACTION_DECLARED --> REACTION_RESOLVED
+                                       |
+                                       v
+                               PERFORM_ACTION (resumed)
+                                       |
+                                       v
+                               ACTION_RESOLVED
+                                       |
+                                       v
+                                    END_TURN
+```
+
+## Usage tips
+
+* Controllers that emulate players (including AI harnesses) should listen to
+  `ACTIONS_AVAILABLE` and publish intents rather than mutating state directly.
+* When monitoring a live simulation, run `scripts/dump_events.py --demo` to see
+  the event order and payload structure.
+* Reaction flows reuse the `PERFORM_ACTION` topic: the initial publication has
+  `await_reactions=True`, the resumed call sets `reactions_resolved=True` with
+  the sorted results.

--- a/scripts/dump_events.py
+++ b/scripts/dump_events.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Diagnostics utility that prints every combat system event passing on the bus."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import pprint
+import time
+from typing import Callable, Iterable, Sequence
+
+from core.event_bus import EventBus
+from core.events import topics as topic_constants
+
+
+def _collect_topic_names(candidates: Iterable[str | tuple[str, str]] | None = None) -> list[str]:
+    if candidates is None:
+        symbols = {
+            value
+            for name, value in vars(topic_constants).items()
+            if name.isupper() and isinstance(value, str)
+        }
+        return sorted(symbols)
+
+    names: set[str] = set()
+    for entry in candidates:
+        if isinstance(entry, tuple):
+            names.add(str(entry[1]))
+        else:
+            names.add(str(entry))
+    return sorted(names)
+
+
+class EventLogger:
+    """Subscriber that prints event payloads as they go through the bus."""
+
+    def __init__(
+        self,
+        *,
+        printer: Callable[[str], None] | None = None,
+        include_timestamp: bool = True,
+        pretty: bool = True,
+    ) -> None:
+        self._printer = printer or print
+        self._include_timestamp = include_timestamp
+        self._formatter = pprint.PrettyPrinter(indent=2) if pretty else None
+
+    def __call__(self, topic: str, **payload: object) -> None:
+        timestamp = ""
+        if self._include_timestamp:
+            timestamp = _dt.datetime.now().strftime("[%H:%M:%S] ")
+        header = f"{timestamp}{topic}"
+        if self._formatter:
+            body = self._formatter.pformat(payload)
+        else:
+            body = str(payload)
+        self._printer(f"{header}\n{body}\n")
+
+
+def attach_to_bus(
+    bus: EventBus,
+    *,
+    topics: Sequence[str] | None = None,
+    include_timestamp: bool = True,
+    pretty: bool = True,
+    printer: Callable[[str], None] | None = None,
+) -> EventLogger:
+    """Subscribe an :class:`EventLogger` to ``bus`` for the provided topics."""
+
+    topic_list = _collect_topic_names(topics)
+    logger = EventLogger(printer=printer, include_timestamp=include_timestamp, pretty=pretty)
+
+    def _make_handler(name: str) -> Callable[..., None]:
+        def _handler(**payload: object) -> None:
+            logger(name, **payload)
+
+        return _handler
+
+    for topic in topic_list:
+        bus.subscribe(topic, _make_handler(topic))
+    return logger
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Dump combat system events for diagnostics.")
+    parser.add_argument(
+        "--topics",
+        metavar="TOPICS",
+        help="Comma-separated list of topic names to monitor (default: all known topics).",
+    )
+    parser.add_argument(
+        "--plain",
+        action="store_true",
+        help="Disable pretty-printing of payloads (raw dict repr).",
+    )
+    parser.add_argument(
+        "--no-timestamp",
+        action="store_true",
+        help="Do not prefix events with the current time.",
+    )
+    parser.add_argument(
+        "--demo",
+        action="store_true",
+        help="Emit a demo event after wiring the logger to illustrate the output format.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    topics = None
+    if args.topics:
+        topics = [entry.strip() for entry in args.topics.split(",") if entry.strip()]
+
+    bus = EventBus()
+    attach_to_bus(
+        bus,
+        topics=topics,
+        include_timestamp=not args.no_timestamp,
+        pretty=not args.plain,
+    )
+
+    print("Event logger ready.")
+    print("Import 'attach_to_bus' from scripts.dump_events to monitor a running bus instance.")
+    print("Press Ctrl+C to exit.")
+
+    if args.demo:
+        bus.publish(topic_constants.REQUEST_ACTIONS, actor_id="demo_actor", reason="demo")
+
+    try:
+        while True:
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        print("\nStopping event logger.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/helpers/pipeline.py
+++ b/tests/helpers/pipeline.py
@@ -1,0 +1,232 @@
+"""Utilities for wiring the declarative action pipeline in tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Optional
+
+from core.actions.intent import ActionIntent, TargetSpec
+from core.actions.selector import ActionSelector
+from core.actions.validation import IntentValidator
+from core.actions.scheduler import ActionScheduler
+from core.actions.performers import ActionPerformer
+from core.event_bus import EventBus
+from core.events import topics
+from core.reactions.manager import ReactionManager
+
+
+class LoggedEventBus(EventBus):
+    """Event bus that records every publication for assertions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.log: list[tuple[str, dict[str, Any]]] = []
+
+    def publish(self, event_type: str, **kwargs: Any) -> None:  # type: ignore[override]
+        self.log.append((event_type, dict(kwargs)))
+        super().publish(event_type, **kwargs)
+
+
+@dataclass
+class SimpleMovementSystem:
+    reachable: list[tuple[int, int, int]] = field(
+        default_factory=lambda: [(1, 0, 1), (0, 1, 1)]
+    )
+    moves: list[tuple[str, tuple[int, int]]] = field(default_factory=list)
+
+    def get_reachable_tiles(self, actor_id: str, distance: int) -> list[tuple[int, int, int]]:
+        return list(self.reachable)
+
+    def move(self, actor_id: str, destination: tuple[int, int], **_: Any) -> bool:
+        self.moves.append((actor_id, tuple(destination)))
+        return True
+
+
+@dataclass
+class SimpleLineOfSight:
+    visible: set[tuple[str, str]]
+
+    def has_line_of_sight(self, source_id: str, target_id: str) -> bool:
+        return (source_id, target_id) in self.visible
+
+
+class SimpleECS:
+    def __init__(self) -> None:
+        self.positions: Dict[str, tuple[int, int]] = {
+            "hero": (0, 0),
+            "ghoul": (0, 1),
+        }
+        self.action_points: Dict[str, int] = {"hero": 2, "ghoul": 1}
+        self.ammunition: Dict[str, int] = {"hero": 3, "ghoul": 0}
+        self.entities: Dict[str, int] = {"hero": 1, "ghoul": 2}
+        self._components: Dict[int, Dict[type, Any]] = {}
+
+    def resolve_entity(self, entity_id: str) -> Optional[int]:
+        return self.entities.get(entity_id)
+
+    def try_get_component(self, internal_id: int, component_type: type) -> Any:
+        return self._components.get(internal_id, {}).get(component_type)
+
+    def add_component(self, internal_id: int, component: Any) -> None:
+        self._components.setdefault(internal_id, {})[type(component)] = component
+
+
+class SimpleRules:
+    def __init__(self, ecs: SimpleECS) -> None:
+        self.ecs = ecs
+        self.movement_system = SimpleMovementSystem()
+        self.line_of_sight = SimpleLineOfSight(
+            {("hero", "ghoul"), ("ghoul", "hero")}
+        )
+        self.attacks: list[dict[str, Any]] = []
+
+    def get_move_distance(self, actor_id: str) -> int:
+        return 4
+
+    def iter_enemy_ids(self, actor_id: str) -> Iterable[str]:
+        return [enemy for enemy in self.ecs.entities if enemy != actor_id]
+
+    def get_position(self, entity_id: str) -> Optional[tuple[int, int]]:
+        return self.ecs.positions.get(entity_id)
+
+    def get_action_points(self, actor_id: str) -> int:
+        return self.ecs.action_points.get(actor_id, 0)
+
+    def get_ammunition(self, actor_id: str) -> int:
+        return self.ecs.ammunition.get(actor_id, 0)
+
+    def get_ranged_range(self, actor_id: str) -> int:
+        return 6
+
+    def resolve_attack(self, attacker: str, target: str, **_: Any) -> dict[str, Any]:
+        record = {"attacker": attacker, "target": target, "hit": True, "damage": 1}
+        self.attacks.append(record)
+        return record
+
+    def is_actor_controlled_by(self, actor_id: str, player_id: str) -> bool:
+        return True
+
+    def iter_reaction_options(self, action_def: Any, intent: Any) -> Iterable[dict[str, Any]]:
+        return ()
+
+
+class AutoController:
+    """Minimal controller that mirrors player-driven input behaviour."""
+
+    def __init__(
+        self,
+        *,
+        default_action: str = "move",
+        controlled_actors: Iterable[str] | None = None,
+    ) -> None:
+        self._bus: LoggedEventBus | None = None
+        self._default_action = default_action
+        self._controlled = set(controlled_actors or [])
+        self.last_requested: Optional[str] = None
+        self.performed: list[str] = []
+        self.last_actions: tuple[dict[str, Any], ...] | None = None
+
+    def bind(self, bus: LoggedEventBus) -> None:
+        self._bus = bus
+        bus.subscribe(topics.REQUEST_ACTIONS, self._handle_request)
+        bus.subscribe(topics.ACTIONS_AVAILABLE, self._handle_actions)
+        bus.subscribe(topics.REACTION_WINDOW_OPENED, self._handle_reactions)
+
+    def on_request_actions(self, actor_id: str) -> None:
+        if not self._controls(actor_id):
+            return
+        self.last_requested = actor_id
+
+    def _handle_request(self, *, actor_id: str, **_: Any) -> None:
+        self.on_request_actions(actor_id)
+
+    def _handle_actions(self, *, actor_id: str, actions: Iterable[dict[str, Any]], **_: Any) -> None:
+        if self._bus is None or not self._controls(actor_id):
+            return
+        if self.last_requested and self.last_requested != actor_id:
+            return
+        self.last_requested = actor_id
+        actions_list = list(actions)
+        if not actions_list:
+            return
+        self.last_actions = tuple(actions_list)
+        selection = next(
+            (action for action in actions_list if action.get("id") == self._default_action),
+            actions_list[0],
+        )
+        targets_payload = selection.get("targets", [])
+        targets = tuple(TargetSpec.from_dict(target) for target in targets_payload)
+        intent = ActionIntent(
+            actor_id=actor_id,
+            action_id=str(selection.get("id")),
+            targets=targets,
+        )
+        self.performed.append(intent.action_id)
+        self._bus.publish(
+            topics.INTENT_SUBMITTED,
+            intent=intent.to_dict(),
+            intent_obj=intent,
+        )
+
+    def _handle_reactions(self, *, actor_id: str, window_id: str, **_: Any) -> None:
+        if self._bus is None or not self._controls(actor_id):
+            return
+        self._bus.publish(
+            topics.REACTION_DECLARED,
+            actor_id=actor_id,
+            passed=True,
+            reaction=None,
+            window_id=window_id,
+        )
+
+    def _controls(self, actor_id: str) -> bool:
+        return not self._controlled or actor_id in self._controlled
+
+
+def build_pipeline(*, default_action: str = "move") -> dict[str, Any]:
+    """Create a fully wired intent pipeline ready for tests."""
+
+    bus = LoggedEventBus()
+    ecs = SimpleECS()
+    rules = SimpleRules(ecs)
+
+    controller = AutoController(default_action=default_action, controlled_actors={"hero"})
+    controller.bind(bus)
+
+    selector = ActionSelector(ecs, rules)
+    validator = IntentValidator(ecs, rules)
+    scheduler = ActionScheduler(ecs)
+    reactions = ReactionManager(rules)
+    performer = ActionPerformer(rules)
+
+    selector.bind(bus)
+    validator.bind(bus)
+    scheduler.bind(bus)
+    reactions.bind(bus)
+    performer.bind(bus)
+
+    def end_turn_on_resolve(*, actor_id: str, **_: Any) -> None:
+        bus.publish(topics.END_TURN, actor_id=actor_id)
+
+    bus.subscribe(topics.ACTION_RESOLVED, end_turn_on_resolve)
+
+    return {
+        "bus": bus,
+        "ecs": ecs,
+        "rules": rules,
+        "controller": controller,
+        "selector": selector,
+        "validator": validator,
+        "scheduler": scheduler,
+        "reactions": reactions,
+        "performer": performer,
+    }
+
+
+__all__ = [
+    "AutoController",
+    "LoggedEventBus",
+    "SimpleECS",
+    "SimpleRules",
+    "build_pipeline",
+]

--- a/tests/test_action_selector.py
+++ b/tests/test_action_selector.py
@@ -1,0 +1,106 @@
+"""High-level tests for the declarative action selector layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import pytest
+
+from core.actions.selector import ActionOption, compute_available_actions
+
+
+@dataclass
+class DummyMovementSystem:
+    reachable: list[tuple[int, int, int]]
+
+    def get_reachable_tiles(self, actor_id: str, max_distance: int):
+        assert actor_id == "hero"
+        assert max_distance == 4
+        return list(self.reachable)
+
+
+@dataclass
+class DummyLineOfSight:
+    visible_pairs: set[tuple[str, str]]
+
+    def has_line_of_sight(self, source_id: str, target_id: str) -> bool:
+        return (source_id, target_id) in self.visible_pairs
+
+
+class DummyRules:
+    def __init__(self) -> None:
+        self.movement_system = DummyMovementSystem(
+            reachable=[(1, 0, 1), (0, 1, 1), (1, 1, 2)]
+        )
+        self.line_of_sight = DummyLineOfSight({("hero", "ghoul"), ("hero", "vampire")})
+
+    def get_move_distance(self, actor_id: str) -> int:
+        return 4
+
+    def iter_enemy_ids(self, actor_id: str) -> Iterable[str]:
+        return ("ghoul", "vampire")
+
+    def get_position(self, entity_id: str):
+        return {
+            "hero": (0, 0),
+            "ghoul": (0, 1),
+            "vampire": (3, 0),
+        }.get(entity_id)
+
+    def get_action_points(self, actor_id: str) -> int:
+        return 3
+
+    def get_ammunition(self, actor_id: str) -> int:
+        return 5
+
+    def get_ranged_range(self, actor_id: str) -> int:
+        return 6
+
+
+class DummyECS:
+    def __init__(self) -> None:
+        self.positions = {"hero": (0, 0), "ghoul": (0, 1), "vampire": (3, 0)}
+        self.action_points = {"hero": 3}
+        self.ammunition = {"hero": 5}
+
+
+@pytest.fixture
+def selector_context():
+    return DummyECS(), DummyRules()
+
+
+def test_selector_filters_targets_by_los(selector_context) -> None:
+    ecs, rules = selector_context
+    rules.line_of_sight.visible_pairs.remove(("hero", "vampire"))
+
+    options = compute_available_actions("hero", ecs, rules)
+    option_map = {opt.action_id: opt for opt in options}
+
+    ranged = option_map["attack_ranged"]
+    assert isinstance(ranged, ActionOption)
+    assert ranged.is_available
+    assert all(target.reference != "vampire" for target in ranged.valid_targets)
+
+
+def test_selector_reports_insufficient_movement(selector_context) -> None:
+    ecs, rules = selector_context
+    rules.movement_system.reachable = []
+
+    options = compute_available_actions("hero", ecs, rules)
+    move = next(opt for opt in options if opt.action_id == "move")
+    assert not move.is_available
+    assert "no_reachable_tiles" in move.predicates_failed
+
+
+def test_selector_blocks_melee_without_adjacent_enemy(selector_context) -> None:
+    ecs, rules = selector_context
+    # Move ghoul farther away so nobody is adjacent.
+    ecs.positions["ghoul"] = (2, 2)
+    rules.get_position = lambda entity_id: ecs.positions.get(entity_id)
+
+    options = compute_available_actions("hero", ecs, rules)
+    melee = next(opt for opt in options if opt.action_id == "attack_melee")
+    assert not melee.is_available
+    assert "no_adjacent_enemies" in melee.predicates_failed
+

--- a/tests/test_ai_input_players.py
+++ b/tests/test_ai_input_players.py
@@ -1,0 +1,121 @@
+"""Scenarios exercising AI agents that leverage player-style input controllers."""
+
+from __future__ import annotations
+
+from core.actions.intent import ActionIntent, TargetSpec
+from core.events import topics
+from tests.helpers.pipeline import AutoController, LoggedEventBus, SimpleRules, build_pipeline
+
+
+class ClassicAI:
+    """Simplified AI that bypasses the action selector and fires intents directly."""
+
+    def __init__(self, bus: LoggedEventBus, actor_id: str, target_id: str) -> None:
+        self.actor_id = actor_id
+        self.target_id = target_id
+        self.bus = bus
+        bus.subscribe(topics.REQUEST_ACTIONS, self._handle_request)
+
+    def _handle_request(self, *, actor_id: str, **_: object) -> None:
+        if actor_id != self.actor_id:
+            return
+        intent = ActionIntent(
+            actor_id=self.actor_id,
+            action_id="attack_melee",
+            targets=(TargetSpec.entity(self.target_id),),
+        )
+        self.bus.publish(
+            topics.INTENT_SUBMITTED,
+            intent=intent.to_dict(),
+            intent_obj=intent,
+        )
+
+
+def _run_turn(bus: LoggedEventBus, actor_id: str) -> None:
+    bus.publish(topics.BEGIN_TURN, actor_id=actor_id)
+    bus.publish(topics.REQUEST_ACTIONS, actor_id=actor_id)
+
+
+def _count_events(bus: LoggedEventBus, topic: str, *, actor_id: str | None = None) -> int:
+    def _payload_actor(entry: dict[str, object]) -> str | None:
+        direct = entry.get("actor_id")
+        if direct:
+            return str(direct)
+        intent = entry.get("intent")
+        if isinstance(intent, dict):
+            return str(intent.get("actor_id")) if intent.get("actor_id") else None
+        return None
+
+    return sum(
+        1
+        for event_topic, payload in bus.log
+        if event_topic == topic and (actor_id is None or _payload_actor(payload) == actor_id)
+    )
+
+
+def test_input_controller_vs_classic_ai() -> None:
+    components = build_pipeline(default_action="attack_melee")
+    bus: LoggedEventBus = components["bus"]
+    rules: SimpleRules = components["rules"]
+
+    classic = ClassicAI(bus, actor_id="ghoul", target_id="hero")
+
+    _run_turn(bus, "hero")
+    _run_turn(bus, "ghoul")
+
+    assert _count_events(bus, topics.ACTIONS_AVAILABLE, actor_id="hero") >= 1
+    assert _count_events(bus, topics.INTENT_SUBMITTED, actor_id="hero") >= 1
+    assert _count_events(bus, topics.INTENT_SUBMITTED, actor_id="ghoul") >= 1
+    assert any(event[0] == topics.ACTION_RESOLVED for event in bus.log)
+    assert len(rules.attacks) >= 2
+
+
+def test_input_controller_mirror_match() -> None:
+    components = build_pipeline(default_action="attack_melee")
+    bus: LoggedEventBus = components["bus"]
+    rules: SimpleRules = components["rules"]
+    hero_controller: AutoController = components["controller"]
+
+    rival_controller = AutoController(default_action="attack_melee", controlled_actors={"ghoul"})
+    rival_controller.bind(bus)
+
+    _run_turn(bus, "hero")
+    _run_turn(bus, "ghoul")
+
+    assert _count_events(bus, topics.ACTIONS_AVAILABLE, actor_id="hero") >= 1
+    assert _count_events(bus, topics.ACTIONS_AVAILABLE, actor_id="ghoul") >= 1
+    assert "attack_melee" in hero_controller.performed
+    assert "attack_melee" in rival_controller.performed
+    assert len(rules.attacks) >= 2
+
+
+def test_free_for_all_with_multiple_input_controllers() -> None:
+    components = build_pipeline(default_action="move")
+    bus: LoggedEventBus = components["bus"]
+    ecs = components["ecs"]
+    rules: SimpleRules = components["rules"]
+
+    extra_ids = [f"agent_{idx}" for idx in range(10)]
+    base_internal_id = max(ecs.entities.values()) + 1
+    for offset, actor_id in enumerate(extra_ids):
+        internal_id = base_internal_id + offset
+        ecs.entities[actor_id] = internal_id
+        ecs.positions[actor_id] = (offset + 1, offset + 1)
+        ecs.action_points[actor_id] = 2
+        ecs.ammunition[actor_id] = 1
+
+    controllers: list[AutoController] = []
+    for actor_id in extra_ids:
+        controller = AutoController(controlled_actors={actor_id}, default_action="move")
+        controller.bind(bus)
+        controllers.append(controller)
+
+    for actor_id in extra_ids:
+        _run_turn(bus, actor_id)
+
+    for actor_id, controller in zip(extra_ids, controllers):
+        assert _count_events(bus, topics.ACTIONS_AVAILABLE, actor_id=actor_id) >= 1
+        assert controller.performed and controller.performed[-1] == "move"
+
+    recent_moves = rules.movement_system.moves[-len(extra_ids):]
+    assert len(recent_moves) == len(extra_ids)

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1,0 +1,129 @@
+"""Tests for reaction window orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import pytest
+
+from core.actions.intent import ActionIntent, TargetSpec
+from core.reactions.manager import ReactionManager
+from core.events import topics
+
+
+@dataclass
+class DummyEventBus:
+    published: list[tuple[str, dict[str, Any]]]
+
+    def __post_init__(self) -> None:
+        self.subscribers: dict[str, list[Any]] = {}
+
+    def subscribe(self, topic: str, handler: Any) -> None:
+        self.subscribers.setdefault(topic, []).append(handler)
+
+    def publish(self, topic: str, /, **payload: Any) -> None:
+        record = (topic, dict(payload))
+        self.published.append(record)
+        for handler in list(self.subscribers.get(topic, [])):
+            handler(**payload)
+
+
+class StubRules:
+    def iter_reaction_options(self, action_def, intent: ActionIntent) -> Iterable[dict[str, Any]]:
+        yield {
+            "id": "defend_dodge",
+            "name": "Dodge",
+            "reaction_speed": "fast",
+        }
+        yield {
+            "id": "counter_attack",
+            "name": "Counter",
+            "reaction_speed": "slow",
+        }
+
+
+@pytest.fixture
+def reaction_context():
+    bus = DummyEventBus([])
+    rules = StubRules()
+    manager = ReactionManager(rules)
+    manager.bind(bus)
+    return bus, manager
+
+
+def _publish_attack(bus: DummyEventBus, *, attackers: list[str], defenders: list[str]) -> ActionIntent:
+    intent = ActionIntent(
+        actor_id=attackers[0],
+        action_id="attack_ranged",
+        targets=tuple(TargetSpec.entity(target) for target in defenders),
+    )
+    bus.publish(
+        topics.PERFORM_ACTION,
+        await_reactions=True,
+        intent=intent.to_dict(),
+        intent_obj=intent,
+    )
+    return intent
+
+
+def test_reaction_manager_opens_windows(reaction_context) -> None:
+    bus, manager = reaction_context
+
+    intent = _publish_attack(bus, attackers=["hero"], defenders=["ghoul"])
+
+    windows = [payload for topic, payload in bus.published if topic == topics.REACTION_WINDOW_OPENED]
+    assert windows
+    window_payload = windows[0]
+    assert window_payload["actor_id"] == "ghoul"
+    assert len(window_payload["options"]) == 2
+
+    # Defender chooses the slow reaction to make sure ordering works later.
+    choice = window_payload["options"][1]
+    bus.publish(
+        topics.REACTION_DECLARED,
+        actor_id="ghoul",
+        reaction=choice,
+        passed=False,
+        window_id=window_payload["window_id"],
+    )
+
+    resolved = [payload for topic, payload in bus.published if topic == topics.REACTION_RESOLVED]
+    assert resolved
+    assert resolved[-1]["reactions"][0]["id"] == "counter_attack"
+
+
+def test_reaction_manager_handles_multiple_defenders(reaction_context) -> None:
+    bus, manager = reaction_context
+
+    intent = _publish_attack(bus, attackers=["hero"], defenders=["ghoul", "vampire"])
+
+    windows = [payload for topic, payload in bus.published if topic == topics.REACTION_WINDOW_OPENED]
+    assert len(windows) == 2
+
+    # First defender picks the slow option, second defender picks the fast one.
+    first_window = windows[0]
+    bus.publish(
+        topics.REACTION_DECLARED,
+        actor_id=first_window["actor_id"],
+        reaction=first_window["options"][1],
+        passed=False,
+        window_id=first_window["window_id"],
+    )
+
+    second_window = windows[1]
+    bus.publish(
+        topics.REACTION_DECLARED,
+        actor_id=second_window["actor_id"],
+        reaction=second_window["options"][0],
+        passed=False,
+        window_id=second_window["window_id"],
+    )
+
+    resolved = [payload for topic, payload in bus.published if topic == topics.REACTION_RESOLVED]
+    assert resolved
+    reactions = resolved[-1]["reactions"]
+    assert reactions[0]["id"] == "defend_dodge"
+    assert reactions[1]["id"] == "counter_attack"
+

--- a/tests/test_turn_flow.py
+++ b/tests/test_turn_flow.py
@@ -1,0 +1,61 @@
+"""Integration tests covering the round-trip action flow."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.events import topics
+from tests.helpers.pipeline import (
+    AutoController,
+    LoggedEventBus,
+    SimpleRules,
+    build_pipeline,
+)
+
+
+@pytest.fixture
+def pipeline_components() -> dict[str, Any]:
+    return build_pipeline()
+
+
+def test_turn_flow_single_move_action(pipeline_components) -> None:
+    bus: LoggedEventBus = pipeline_components["bus"]
+    rules: SimpleRules = pipeline_components["rules"]
+
+    bus.publish(topics.BEGIN_TURN, actor_id="hero")
+    bus.publish(topics.REQUEST_ACTIONS, actor_id="hero")
+
+    event_sequence = [topic for topic, _ in bus.log]
+    expected = [
+        topics.BEGIN_TURN,
+        topics.REQUEST_ACTIONS,
+        topics.ACTIONS_AVAILABLE,
+        topics.INTENT_SUBMITTED,
+        topics.INTENT_VALIDATED,
+        topics.ACTION_ENQUEUED,
+        topics.PERFORM_ACTION,
+        topics.ACTION_RESOLVED,
+        topics.END_TURN,
+    ]
+    assert event_sequence[: len(expected)] == expected
+    assert rules.movement_system.moves == [("hero", (1, 0))]
+
+
+def test_turn_flow_attack_triggers_resolution(pipeline_components) -> None:
+    bus: LoggedEventBus = pipeline_components["bus"]
+    rules: SimpleRules = pipeline_components["rules"]
+    controller: AutoController = pipeline_components["controller"]
+
+    controller._default_action = "attack_melee"
+
+    bus.publish(topics.BEGIN_TURN, actor_id="hero")
+    bus.publish(topics.REQUEST_ACTIONS, actor_id="hero")
+
+    assert any(record[0] == topics.ACTION_RESOLVED for record in bus.log)
+    assert rules.attacks
+    last_attack = rules.attacks[-1]
+    assert last_attack["attacker"] == "hero"
+    assert last_attack["target"] == "ghoul"
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,126 @@
+"""Unit tests for the action validation pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from core.actions.intent import ActionIntent, TargetSpec
+from core.actions.validation import validate_intent
+
+
+@dataclass
+class DummyECS:
+    entities: dict[str, object]
+
+    def resolve_entity(self, entity_id: str):
+        return self.entities.get(entity_id)
+
+    def has_entity(self, entity_id: str) -> bool:
+        return entity_id in self.entities
+
+
+class DummyRules:
+    def __init__(self) -> None:
+        self._locked: set[str] = set()
+        self._blocked: dict[str, set[str]] = {}
+        self._ownership: dict[tuple[str, str], bool] = {}
+        self._resources: dict[str, dict[str, int]] = {}
+
+    def set_locked(self, actor_id: str, locked: bool = True) -> None:
+        if locked:
+            self._locked.add(actor_id)
+        else:
+            self._locked.discard(actor_id)
+
+    def set_blocked(self, actor_id: str, actions: set[str]) -> None:
+        self._blocked[actor_id] = set(actions)
+
+    def set_owner(self, actor_id: str, player_id: str, allowed: bool) -> None:
+        self._ownership[(actor_id, player_id)] = allowed
+
+    def set_resource(self, actor_id: str, resource: str, amount: int) -> None:
+        self._resources.setdefault(actor_id, {})[resource] = amount
+
+    def is_action_locked(self, actor_id: str) -> bool:
+        return actor_id in self._locked
+
+    def get_blocked_actions(self, actor_id: str):
+        return self._blocked.get(actor_id, set())
+
+    def is_actor_controlled_by(self, actor_id: str, player_id: str) -> bool:
+        return self._ownership.get((actor_id, player_id), False)
+
+    def get_action_points(self, actor_id: str) -> int:
+        return self._resources.get(actor_id, {}).get("action_points", 0)
+
+
+@pytest.fixture
+def validation_context():
+    ecs = DummyECS({"hero": object(), "ghoul": object()})
+    rules = DummyRules()
+    rules.set_resource("hero", "action_points", 1)
+    return ecs, rules
+
+
+def test_validation_rejects_locked_actor(validation_context) -> None:
+    ecs, rules = validation_context
+    rules.set_locked("hero")
+
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="move",
+        targets=(TargetSpec.tile((1, 2)),),
+    )
+
+    ok, reason, _ = validate_intent(intent, ecs, rules)
+    assert not ok
+    assert reason == "actor_locked"
+
+
+def test_validation_rejects_blocked_action(validation_context) -> None:
+    ecs, rules = validation_context
+    rules.set_blocked("hero", {"attack_melee"})
+
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="attack_melee",
+        targets=(TargetSpec.entity("ghoul"),),
+    )
+
+    ok, reason, _ = validate_intent(intent, ecs, rules)
+    assert not ok
+    assert reason == "action_blocked"
+
+
+def test_validation_checks_resource_cost(validation_context) -> None:
+    ecs, rules = validation_context
+    rules.set_resource("hero", "action_points", 0)
+
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="attack_melee",
+        targets=(TargetSpec.entity("ghoul"),),
+    )
+
+    ok, reason, _ = validate_intent(intent, ecs, rules)
+    assert not ok
+    assert reason == "insufficient_action_points"
+
+
+def test_validation_checks_ownership(validation_context) -> None:
+    ecs, rules = validation_context
+    rules.set_owner("hero", "player-a", False)
+
+    intent = ActionIntent(
+        actor_id="hero",
+        action_id="move",
+        targets=(TargetSpec.tile((0, 1)),),
+        source_player_id="player-a",
+    )
+
+    ok, reason, _ = validate_intent(intent, ecs, rules)
+    assert not ok
+    assert reason == "unauthorised_actor"
+


### PR DESCRIPTION
## Summary
- add dedicated helpers and fixtures to exercise the declarative intent pipeline end-to-end
- cover action selection, validation, reaction ordering, turn flow, and input-driven AI scenarios with new pytest suites
- document the event bus choreography and supply a diagnostic script to dump combat events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e10e11a05c832d845b5a7b350b1ee9