### PR TITLE
Refine ECS map grid helpers and tests

### DIFF
--- a/modules/maps/components.py
+++ b/modules/maps/components.py
@@ -1,0 +1,133 @@
+"""Map-related ECS components and supporting data structures."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, TypeVar, Union
+
+from modules.maps.terrain_types import TerrainDescriptor, TerrainFlags
+
+
+IntGrid = List[List[int]]
+BoolGrid = List[List[bool]]
+_GridValue = TypeVar("_GridValue", int, bool)
+
+
+@dataclass(slots=True)
+class MapGrid:
+    """Holds the terrain information for a rectangular map."""
+
+    width: int
+    height: int
+    cell_size: int
+    flags: IntGrid | None = None
+    move_cost: IntGrid | None = None
+    hazard_damage: IntGrid | None = None
+    blocks_move_mask: BoolGrid | None = None
+    blocks_los_mask: BoolGrid | None = None
+
+    def __post_init__(self) -> None:
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError("width and height must be positive")
+        if self.cell_size <= 0:
+            raise ValueError("cell_size must be positive")
+
+        self.flags = self._ensure_grid(self.flags, 0)
+        self.move_cost = self._ensure_grid(self.move_cost, 1)
+        self.hazard_damage = self._ensure_grid(self.hazard_damage, 0)
+        self.blocks_move_mask = self._ensure_grid(self.blocks_move_mask, False)
+        self.blocks_los_mask = self._ensure_grid(self.blocks_los_mask, False)
+
+    def _ensure_grid(
+        self,
+        grid: Union[IntGrid, BoolGrid, None],
+        default: _GridValue,
+    ) -> Union[IntGrid, BoolGrid]:
+        if grid is None:
+            return [
+                [default for _ in range(self.width)]
+                for _ in range(self.height)
+            ]
+
+        if len(grid) != self.height or any(len(row) != self.width for row in grid):
+            raise ValueError("grid dimensions do not match width and height")
+
+        converter = bool if isinstance(default, bool) else int
+        return [
+            [converter(value) for value in row]
+            for row in grid
+        ]
+
+    def _clamp_coords(self, x: int, y: int) -> tuple[int, int]:
+        clamped_x = min(max(x, 0), self.width - 1)
+        clamped_y = min(max(y, 0), self.height - 1)
+        return clamped_x, clamped_y
+
+    def get_flags(self, x: int, y: int) -> TerrainFlags:
+        """Return the terrain flags at the requested coordinates."""
+
+        cx, cy = self._clamp_coords(x, y)
+        return TerrainFlags(self.flags[cy][cx])
+
+    def get_move_cost(self, x: int, y: int) -> int:
+        """Retrieve the movement cost of a tile, clamping out-of-range indices."""
+
+        cx, cy = self._clamp_coords(x, y)
+        return self.move_cost[cy][cx]
+
+    def get_hazard_damage(self, x: int, y: int) -> int:
+        """Retrieve the hazard damage associated with a tile."""
+
+        cx, cy = self._clamp_coords(x, y)
+        return self.hazard_damage[cy][cx]
+
+    def blocks_movement(self, x: int, y: int) -> bool:
+        """Return whether the tile blocks movement."""
+
+        cx, cy = self._clamp_coords(x, y)
+        return self.blocks_move_mask[cy][cx]
+
+    def blocks_los(self, x: int, y: int) -> bool:
+        """Return whether the tile blocks line of sight."""
+
+        cx, cy = self._clamp_coords(x, y)
+        return self.blocks_los_mask[cy][cx]
+
+    def set_cell(self, x: int, y: int, descriptor: TerrainDescriptor) -> None:
+        """Write terrain data for the requested coordinates."""
+
+        cx, cy = self._clamp_coords(x, y)
+        flags_value = int(descriptor.flags)
+        blocks_move = bool(
+            descriptor.flags
+            & (TerrainFlags.BLOCKS_MOVE | TerrainFlags.IMPASSABLE | TerrainFlags.VOID)
+        )
+        blocks_los = bool(descriptor.flags & TerrainFlags.BLOCKS_LOS)
+
+        self.flags[cy][cx] = flags_value
+        self.move_cost[cy][cx] = (
+            descriptor.move_cost if descriptor.move_cost is not None else 0
+        )
+        self.hazard_damage[cy][cx] = descriptor.hazard_damage
+        self.blocks_move_mask[cy][cx] = blocks_move
+        self.blocks_los_mask[cy][cx] = blocks_los
+
+
+@dataclass(slots=True)
+class MapMeta:
+    """Metadata describing a map instance."""
+
+    name: str
+    biome: str
+    seed: int | None = None
+
+
+@dataclass(slots=True)
+class MapComponent:
+    """ECS component storing a map grid and its metadata."""
+
+    grid: MapGrid
+    meta: MapMeta
+
+
+__all__ = ["MapGrid", "MapMeta", "MapComponent"]
+

--- a/modules/maps/components.py
+++ b/modules/maps/components.py
@@ -104,9 +104,7 @@ class MapGrid:
         blocks_los = bool(descriptor.flags & TerrainFlags.BLOCKS_LOS)
 
         self.flags[cy][cx] = flags_value
-        self.move_cost[cy][cx] = (
-            descriptor.move_cost if descriptor.move_cost is not None else 0
-        )
+        self.move_cost[cy][cx] = descriptor.move_cost or 0
         self.hazard_damage[cy][cx] = descriptor.hazard_damage
         self.blocks_move_mask[cy][cx] = blocks_move
         self.blocks_los_mask[cy][cx] = blocks_los

--- a/tests/test_map_component.py
+++ b/tests/test_map_component.py
@@ -1,0 +1,52 @@
+"""Tests for the map ECS component structures."""
+from modules.maps.components import MapComponent, MapGrid, MapMeta
+from modules.maps.terrain_types import TERRAIN_CATALOG, TerrainFlags
+
+
+def test_map_component_entity_creation():
+    grid = MapGrid(width=3, height=2, cell_size=1)
+    meta = MapMeta(name="Test Map", biome="forest", seed=42)
+    component = MapComponent(grid=grid, meta=meta)
+
+    # Using the fallback ECS world from ECSManager ensures the component can
+    # be attached to an entity without requiring external dependencies.
+    from ecs.ecs_manager import ECSManager
+
+    ecs_manager = ECSManager()
+    entity_id = ecs_manager.world.create_entity(component)
+
+    stored_component = ecs_manager.world.component_for_entity(entity_id, MapComponent)
+    assert stored_component is component
+
+
+def test_map_grid_set_and_get_cell_data():
+    grid = MapGrid(width=2, height=2, cell_size=1)
+
+    wall_descriptor = TERRAIN_CATALOG["wall"]
+    floor_descriptor = TERRAIN_CATALOG["floor"]
+    hazard_descriptor = TERRAIN_CATALOG["hazard"]
+
+    # Coordinates beyond the grid should clamp to the closest valid cell.
+    grid.set_cell(5, 5, wall_descriptor)
+    assert grid.get_flags(5, 5) == wall_descriptor.flags
+    assert grid.blocks_movement(5, 5) is True
+    assert grid.blocks_los(5, 5) is True
+    assert grid.get_move_cost(5, 5) == 0  # Impassable terrain
+
+    grid.set_cell(0, 1, hazard_descriptor)
+    assert grid.get_hazard_damage(0, 1) == hazard_descriptor.hazard_damage
+    assert grid.blocks_movement(0, 1) is False
+
+    grid.set_cell(-1, -1, floor_descriptor)
+    assert grid.get_flags(-10, -10) == TerrainFlags(0)
+    assert grid.blocks_movement(-10, -10) is False
+    assert grid.blocks_los(-10, -10) is False
+    assert grid.get_move_cost(-10, -10) == floor_descriptor.move_cost
+
+
+def test_grid_initialises_from_existing_data_without_aliasing():
+    flags = [[int(TerrainFlags.BLOCKS_MOVE)]]
+    grid = MapGrid(width=1, height=1, cell_size=1, flags=flags)
+
+    flags[0][0] = 0
+    assert grid.get_flags(0, 0) == TerrainFlags.BLOCKS_MOVE


### PR DESCRIPTION
## Summary
- introduce map grid, metadata, and component dataclasses for ECS map representation
- clamp tile access helpers, expose movement/LOS query helpers, and update per-cell data from terrain descriptors
- add tests covering component registration, grid read/write behaviour, and defensive copying of initial data

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1539af834832db9d8a35db9a6766e