### PR TITLE
Add ECS map-based movement, LOS, and cover helpers

### DIFF
--- a/modules/cover/__init__.py
+++ b/modules/cover/__init__.py
@@ -1,0 +1,6 @@
+"""Cover helpers operating on the active ECS map."""
+from .system import CoverSystem
+
+__all__ = [
+    "CoverSystem",
+]

--- a/modules/cover/system.py
+++ b/modules/cover/system.py
@@ -1,0 +1,75 @@
+"""Cover calculations based on :class:`MapComponent` tiles."""
+from __future__ import annotations
+
+from typing import Optional, Sequence, Tuple
+
+from modules.maps.components import MapGrid
+from modules.maps.resolver import ActiveMapResolver, MapResolution
+from modules.maps.terrain_types import TerrainFlags
+
+GridCoord = Tuple[int, int]
+
+_NO_COVER_BONUS = -2
+_COVER_PRIORITY = (
+    (TerrainFlags.FORTIFICATION, 1),
+    (TerrainFlags.COVER_HEAVY, 0),
+    (TerrainFlags.COVER_LIGHT, -1),
+)
+
+
+class CoverSystem:
+    """Derive cover bonuses directly from map tiles."""
+
+    def __init__(
+        self,
+        ecs_manager: "ECSManager",
+        *,
+        event_bus: Optional[object] = None,
+        map_resolver: Optional[ActiveMapResolver] = None,
+    ) -> None:
+        self._resolver = map_resolver or ActiveMapResolver(ecs_manager, event_bus=event_bus)
+
+    def _get_grid(self) -> MapGrid:
+        resolution: MapResolution = self._resolver.get_active_map()
+        return resolution.grid
+
+    def tile_cover_bonus(self, x: int, y: int, *, default: int = _NO_COVER_BONUS) -> int:
+        """Return the cover modifier supplied by the tile at ``(x, y)``."""
+
+        grid = self._get_grid()
+        if not grid.in_bounds(x, y):
+            return default
+
+        flags = TerrainFlags(grid.flags[y][x])
+        for mask, bonus in _COVER_PRIORITY:
+            if flags & mask:
+                return bonus
+        return default
+
+    def cover_bonus(
+        self,
+        target: GridCoord,
+        *,
+        edge_offsets: Optional[Sequence[GridCoord]] = None,
+        default: int = _NO_COVER_BONUS,
+    ) -> int:
+        """Return the best cover modifier available to a defender.
+
+        ``target`` is the tile occupied by the defender.  ``edge_offsets`` can be
+        used to sample neighbouring tiles (for example, half-height walls or
+        adjacent barricades) – the highest bonus encountered is returned.
+        """
+
+        tx, ty = target
+        bonuses = [self.tile_cover_bonus(tx, ty, default=default)]
+
+        if edge_offsets:
+            for dx, dy in edge_offsets:
+                bonuses.append(self.tile_cover_bonus(tx + dx, ty + dy, default=default))
+
+        return max(bonuses)
+
+
+__all__ = [
+    "CoverSystem",
+]

--- a/modules/los/__init__.py
+++ b/modules/los/__init__.py
@@ -1,0 +1,6 @@
+"""Line of sight helpers using ECS map data."""
+from .system import LineOfSightSystem
+
+__all__ = [
+    "LineOfSightSystem",
+]

--- a/modules/los/system.py
+++ b/modules/los/system.py
@@ -1,0 +1,100 @@
+
+"""Line of sight helpers driven by :class:`MapComponent` data."""
+from __future__ import annotations
+
+from typing import Iterator, Optional, Sequence, Tuple
+
+from modules.maps.components import MapGrid
+from modules.maps.resolver import ActiveMapResolver, MapResolution
+from modules.maps.terrain_types import TerrainFlags
+
+GridCoord = Tuple[int, int]
+_BLOCKING_FLAGS = (
+    TerrainFlags.BLOCKS_LOS
+    | TerrainFlags.IMPASSABLE
+    | TerrainFlags.WALL
+)
+
+
+def _bresenham(start: GridCoord, end: GridCoord) -> Iterator[GridCoord]:
+    """Yield integer coordinates between ``start`` and ``end`` (inclusive)."""
+
+    x0, y0 = start
+    x1, y1 = end
+    dx = abs(x1 - x0)
+    sx = 1 if x0 < x1 else -1
+    dy = -abs(y1 - y0)
+    sy = 1 if y0 < y1 else -1
+    err = dx + dy
+
+    while True:
+        yield x0, y0
+        if x0 == x1 and y0 == y1:
+            break
+        e2 = 2 * err
+        if e2 >= dy:
+            err += dy
+            x0 += sx
+        if e2 <= dx:
+            err += dx
+            y0 += sy
+
+
+class LineOfSightSystem:
+    """Perform simple raycasts on the active map grid."""
+
+    def __init__(
+        self,
+        ecs_manager: "ECSManager",
+        *,
+        event_bus: Optional[object] = None,
+        map_resolver: Optional[ActiveMapResolver] = None,
+    ) -> None:
+        self._resolver = map_resolver or ActiveMapResolver(ecs_manager, event_bus=event_bus)
+
+    def _get_grid(self) -> MapGrid:
+        resolution: MapResolution = self._resolver.get_active_map()
+        return resolution.grid
+
+    def has_line_of_sight(
+        self,
+        start: GridCoord,
+        end: GridCoord,
+        *,
+        ignore_target_blocking: bool = False,
+    ) -> bool:
+        """Return ``True`` when ``start`` can see ``end``."""
+
+        grid = self._get_grid()
+        if not grid.in_bounds(*start) or not grid.in_bounds(*end):
+            return False
+
+        for index, (x, y) in enumerate(_bresenham(start, end)):
+            if index == 0:
+                continue  # Skip the origin tile.
+
+            if not grid.in_bounds(x, y):
+                return False
+
+            if grid.blocks_los_mask[y][x]:
+                if ignore_target_blocking and (x, y) == end:
+                    continue
+                return False
+
+            flags = TerrainFlags(grid.flags[y][x])
+            if flags & _BLOCKING_FLAGS:
+                if ignore_target_blocking and (x, y) == end:
+                    continue
+                return False
+
+        return True
+
+    def trace_ray(self, start: GridCoord, end: GridCoord) -> Sequence[GridCoord]:
+        """Return the discrete coordinates followed by ``has_line_of_sight``."""
+
+        return list(_bresenham(start, end))
+
+
+__all__ = [
+    "LineOfSightSystem",
+]

--- a/modules/maps/components.py
+++ b/modules/maps/components.py
@@ -62,6 +62,11 @@ class MapGrid:
         clamped_y = min(max(y, 0), self.height - 1)
         return clamped_x, clamped_y
 
+    def in_bounds(self, x: int, y: int) -> bool:
+        """Return ``True`` when ``(x, y)`` lies within the grid bounds."""
+
+        return 0 <= x < self.width and 0 <= y < self.height
+
     def get_flags(self, x: int, y: int) -> TerrainFlags:
         """Return the terrain flags at the requested coordinates."""
 

--- a/modules/maps/resolver.py
+++ b/modules/maps/resolver.py
@@ -1,0 +1,124 @@
+
+"""Utilities for resolving the active :class:`~modules.maps.components.MapComponent`."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from modules.maps.components import MapComponent, MapGrid
+
+CURRENT_MAP_REQUESTED = "current_map_requested"
+"""Published by systems that require the active map entity."""
+
+CURRENT_MAP_CHANGED = "current_map_changed"
+"""Notification emitted when the active map entity changes."""
+
+
+@dataclass(frozen=True)
+class MapResolution:
+    """Lightweight record returned by :class:`ActiveMapResolver`."""
+
+    entity_id: str
+    component: MapComponent
+
+    @property
+    def grid(self) -> MapGrid:
+        return self.component.grid
+
+
+class ActiveMapResolver:
+    """Resolve the currently active map using the ECS and/or event bus."""
+
+    def __init__(
+        self,
+        ecs_manager: "ECSManager",
+        *,
+        event_bus: Optional[object] = None,
+    ) -> None:
+        self._ecs_manager = ecs_manager
+        self._event_bus = event_bus
+        self._cached: Optional[MapResolution] = None
+
+        if event_bus is not None:
+            subscribe = getattr(event_bus, "subscribe", None)
+            if callable(subscribe):
+                subscribe(CURRENT_MAP_CHANGED, self._on_map_changed)
+
+    def _on_map_changed(self, **payload: object) -> None:
+        entity_id = payload.get("entity_id")
+        component = payload.get("map_component")
+
+        if isinstance(entity_id, str) and isinstance(component, MapComponent):
+            self._cached = MapResolution(entity_id=entity_id, component=component)
+            return
+
+        if isinstance(entity_id, str):
+            component = self._fetch_component(entity_id)
+            if component is not None:
+                self._cached = MapResolution(entity_id=entity_id, component=component)
+                return
+
+        self._cached = None
+
+    def get_active_map(self) -> MapResolution:
+        """Return the active map entity/component pair."""
+
+        if self._cached is None:
+            self._cached = self._resolve_active_map()
+        return self._cached
+
+    def invalidate(self) -> None:
+        """Clear any cached map reference."""
+
+        self._cached = None
+
+    def _resolve_active_map(self) -> MapResolution:
+        if self._event_bus is not None:
+            resolution = self._resolve_via_event_bus()
+            if resolution is not None:
+                return resolution
+
+        for entity_id, component in self._ecs_manager.iter_with_id(MapComponent):
+            return MapResolution(entity_id=entity_id, component=component)
+
+        raise LookupError("No active map entity providing MapComponent was found.")
+
+    def _resolve_via_event_bus(self) -> Optional[MapResolution]:
+        provided: dict[str, object] = {}
+
+        def _provider(
+            entity_id: Optional[str] = None,
+            map_component: Optional[MapComponent] = None,
+        ) -> None:
+            if map_component is None and isinstance(entity_id, str):
+                fetched = self._fetch_component(entity_id)
+            else:
+                fetched = map_component
+
+            if isinstance(entity_id, str) and isinstance(fetched, MapComponent):
+                provided["entity_id"] = entity_id
+                provided["map_component"] = fetched
+
+        publish = getattr(self._event_bus, "publish", None)
+        if callable(publish):
+            publish(CURRENT_MAP_REQUESTED, provide=_provider)
+
+        entity_id = provided.get("entity_id")
+        component = provided.get("map_component")
+        if isinstance(entity_id, str) and isinstance(component, MapComponent):
+            return MapResolution(entity_id=entity_id, component=component)
+        return None
+
+    def _fetch_component(self, entity_id: str) -> Optional[MapComponent]:
+        components = self._ecs_manager.get_components_for_entity(entity_id, MapComponent)
+        if components:
+            return components[0]
+        return None
+
+
+__all__ = [
+    "ActiveMapResolver",
+    "CURRENT_MAP_CHANGED",
+    "CURRENT_MAP_REQUESTED",
+    "MapResolution",
+]

--- a/modules/movement/__init__.py
+++ b/modules/movement/__init__.py
@@ -1,0 +1,9 @@
+"""Movement system helpers operating on ECS map components."""
+from .system import MovementError, MovementSystem, TileBlockedError, TileInfo
+
+__all__ = [
+    "MovementError",
+    "MovementSystem",
+    "TileBlockedError",
+    "TileInfo",
+]

--- a/modules/movement/system.py
+++ b/modules/movement/system.py
@@ -1,0 +1,107 @@
+
+"""Grid-aware movement helpers that operate on :class:`MapComponent` data."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence, Tuple
+
+from modules.maps.components import MapGrid
+from modules.maps.resolver import ActiveMapResolver, MapResolution
+from modules.maps.terrain_types import TerrainFlags
+
+GridCoord = Tuple[int, int]
+
+
+class MovementError(RuntimeError):
+    """Base exception raised by :class:`MovementSystem`."""
+
+
+class TileBlockedError(MovementError):
+    """Raised when attempting to move through an impassable tile."""
+
+
+@dataclass(frozen=True)
+class TileInfo:
+    """Snapshot of a single grid cell."""
+
+    x: int
+    y: int
+    move_cost: int
+    flags: TerrainFlags
+    blocks_movement: bool
+
+    @property
+    def is_walkable(self) -> bool:
+        return not self.blocks_movement and TerrainFlags.IMPASSABLE not in self.flags
+
+
+class MovementSystem:
+    """Movement utilities backed by a :class:`~modules.maps.components.MapGrid`."""
+
+    def __init__(
+        self,
+        ecs_manager: "ECSManager",
+        *,
+        event_bus: Optional[object] = None,
+        map_resolver: Optional[ActiveMapResolver] = None,
+    ) -> None:
+        self._resolver = map_resolver or ActiveMapResolver(ecs_manager, event_bus=event_bus)
+
+    def _get_resolution(self) -> MapResolution:
+        return self._resolver.get_active_map()
+
+    def get_grid(self) -> MapGrid:
+        """Return the currently active map grid."""
+
+        return self._get_resolution().grid
+
+    def describe_tile(self, x: int, y: int) -> TileInfo:
+        """Return a :class:`TileInfo` view of the requested coordinates."""
+
+        grid = self.get_grid()
+        if not grid.in_bounds(x, y):
+            raise IndexError(f"coordinates ({x}, {y}) are outside the grid bounds")
+
+        flags = TerrainFlags(grid.flags[y][x])
+        blocks = bool(grid.blocks_move_mask[y][x]) or bool(flags & TerrainFlags.IMPASSABLE)
+        move_cost = int(grid.move_cost[y][x])
+        return TileInfo(x=x, y=y, move_cost=move_cost, flags=flags, blocks_movement=blocks)
+
+    def can_enter(self, x: int, y: int) -> bool:
+        """Return ``True`` when the tile can be traversed."""
+
+        try:
+            info = self.describe_tile(x, y)
+        except IndexError:
+            return False
+        return info.is_walkable
+
+    def get_move_cost(self, x: int, y: int, *, require_walkable: bool = True) -> int:
+        """Return the terrain movement cost for ``(x, y)``."""
+
+        info = self.describe_tile(x, y)
+        if require_walkable and not info.is_walkable:
+            raise TileBlockedError(f"Tile ({x}, {y}) blocks movement: {info.flags!r}")
+        return info.move_cost
+
+    def path_cost(self, path: Sequence[GridCoord]) -> int:
+        """Return the cumulative cost of traversing ``path``."""
+
+        total = 0
+        for x, y in path:
+            total += self.get_move_cost(x, y)
+        return total
+
+    def validate_path(self, path: Iterable[GridCoord]) -> None:
+        """Ensure every tile within ``path`` is traversable."""
+
+        for x, y in path:
+            self.get_move_cost(x, y, require_walkable=True)
+
+
+__all__ = [
+    "MovementError",
+    "MovementSystem",
+    "TileBlockedError",
+    "TileInfo",
+]


### PR DESCRIPTION
## Summary
- add an ActiveMapResolver utility to share access to the active map entity
- implement grid-backed movement, line-of-sight, and cover systems that rely on MapComponent data instead of a global game state
- expose the new systems via package modules for use across the codebase

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e157075548832dbf0a06d345981a5b