### PR TITLE
Add Tiled map schema documentation and parsing helpers

### DIFF
--- a/modules/maps/spec.py
+++ b/modules/maps/spec.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Sequence
 
 import json
+import logging
 
 from modules.maps.components import MapComponent, MapGrid, MapMeta
 from modules.maps.terrain_types import (
@@ -15,6 +16,9 @@ from modules.maps.terrain_types import (
     TerrainFlags,
     combine,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 CellSpec = str | list[str]
@@ -275,8 +279,8 @@ def load_json(path: str | Path) -> MapSpec:
     except json.JSONDecodeError as exc:
         # Add the file path to the message while preserving original metadata.
         message = f"{exc.msg} (file: {source})"
-        print(f"Error parsing JSON in file '{source}': {exc.msg}")
-        raise json.JSONDecodeError(message, exc.doc, exc.pos) from exc
+        logger.error("Error parsing JSON in file '%s': %s", source, exc.msg)
+        raise exc.__class__(message, exc.doc, exc.pos) from exc
     meta_data = data.get("meta", {})
     meta = MapMeta(
         name=meta_data.get("name", ""),

--- a/modules/maps/spec.py
+++ b/modules/maps/spec.py
@@ -273,7 +273,7 @@ def load_json(path: str | Path) -> MapSpec:
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
-        # Ajoute le chemin du fichier au message tout en préservant les métadonnées d'origine.
+        # Add the file path to the message while preserving original metadata.
         message = f"{exc.msg} (file: {source})"
         print(f"Error parsing JSON in file '{source}': {exc.msg}")
         raise json.JSONDecodeError(message, exc.doc, exc.pos) from exc

--- a/modules/maps/spec.py
+++ b/modules/maps/spec.py
@@ -273,9 +273,10 @@ def load_json(path: str | Path) -> MapSpec:
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
-        # Enhanced error message with file path, but preserve original exception context
+        # Ajoute le chemin du fichier au message tout en préservant les métadonnées d'origine.
+        message = f"{exc.msg} (file: {source})"
         print(f"Error parsing JSON in file '{source}': {exc.msg}")
-        raise
+        raise json.JSONDecodeError(message, exc.doc, exc.pos) from exc
     meta_data = data.get("meta", {})
     meta = MapMeta(
         name=meta_data.get("name", ""),

--- a/modules/maps/spec.py
+++ b/modules/maps/spec.py
@@ -278,8 +278,8 @@ def load_json(path: str | Path) -> MapSpec:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
         # Add the file path to the message while preserving original metadata.
-        message = f"{exc.msg} (file: {source})"
-        logger.error("Error parsing JSON in file '%s': %s", source, exc.msg)
+        message = f"{exc.msg} (fichier : {source})"
+        logger.exception("Erreur lors de l'analyse du JSON dans le fichier '%s'", source)
         raise exc.__class__(message, exc.doc, exc.pos) from exc
     meta_data = data.get("meta", {})
     meta = MapMeta(

--- a/modules/maps/tiled_schema.md
+++ b/modules/maps/tiled_schema.md
@@ -16,14 +16,14 @@
 ## Propriétés de tuiles
 Les propriétés peuvent être définies au niveau du tileset ou d'une tuile individuelle. Les valeurs sont lues dans cet ordre : tuile ➝ tileset ➝ valeurs de repli ci-dessous.
 
-| Propriété         | Type   | Valeurs autorisées                                    | Valeur de repli | Effet gameplay |
-|-------------------|--------|--------------------------------------------------------|-----------------|----------------|
-| `move_cost`       | int    | ≥ 0 (`None` réservé aux murs/void internes)            | `1`             | Coût standard du sol.
-| `blocks_move`     | bool   | `true` / `false`                                       | `false`         | Bloque le déplacement.
-| `blocks_los`      | bool   | `true` / `false`                                       | `false`         | Bloque la ligne de vue.
-| `cover`           | str    | `"none"`, `"light"`, `"heavy"`, `"fortification"`   | `"none"`       | Flags de couvert appliqués.
-| `hazard`          | str    | `"none"`, `"dangerous"`, `"very_dangerous"`        | `"none"`       | Flags + dégâts de terrain.
-| `hazard_timing`   | str    | `"on_enter"`, `"end_of_turn"`, `"per_tile"`        | `"on_enter"`   | Moment d'application des dégâts.
+| Propriété       | Type | Valeurs autorisées                                | Valeur de repli | Effet gameplay |
+|-----------------|------|----------------------------------------------------|-----------------|----------------|
+| `move_cost`     | int  | ≥ 0 (`None` réservé aux murs/void internes)        | `1`             | Coût standard du sol.
+| `blocks_move`   | bool | `true` / `false`                                   | `false`         | Bloque le déplacement.
+| `blocks_los`    | bool | `true` / `false`                                   | `false`         | Bloque la ligne de vue.
+| `cover`         | str  | `"none"`, `"light"`, `"heavy"`, `"fortification"` | `"none"`       | Flags de couvert appliqués.
+| `hazard`        | str  | `"none"`, `"dangerous"`, `"very_dangerous"`      | `"none"`       | Flags + dégâts de terrain.
+| `hazard_timing` | str  | `"on_enter"`, `"end_of_turn"`, `"per_tile"`      | `"on_enter"`   | Moment d'application des dégâts.
 
 Les valeurs de repli correspondent au terrain « sol » (floor). Elles sont appliquées dès qu'une propriété est absente afin de garantir un état jouable cohérent.
 

--- a/modules/maps/tiled_schema.md
+++ b/modules/maps/tiled_schema.md
@@ -22,7 +22,7 @@ Propriété       | Type | Valeurs autorisées                                | 
 `blocks_move`   | bool | `true` / `false` (`1` / `0`, `yes` / `no`, `on` / `off` acceptés) | `false`         | Bloque le déplacement.
 `blocks_los`    | bool | `true` / `false` (`1` / `0`, `yes` / `no`, `on` / `off` acceptés) | `false`         | Bloque la ligne de vue.
 `cover`         | str  | `"none"`, `"light"`, `"heavy"`, `"fortification"` | `"none"`       | Flags de couvert appliqués.
-`hazard`        | str  | `"none"`, `"dangerous"`, `"very_dangerous"`      | `"none"`       | Flags + dégâts de terrain.
+`hazard`        | str  | `"none"`, `"dangerous"`, `"very_dangerous"`      | `"none"`       | Flags + dégâts de terrain (`dangerous` : 5, `very_dangerous` : 10).
 `hazard_timing` | str  | `"on_enter"`, `"end_of_turn"`, `"per_tile"`      | `"on_enter"`   | Moment d'application des dégâts.
 
 Les valeurs de repli correspondent au terrain « sol » (floor). Elles sont appliquées dès qu'une propriété est absente afin de garantir un état jouable cohérent.

--- a/modules/maps/tiled_schema.md
+++ b/modules/maps/tiled_schema.md
@@ -1,0 +1,31 @@
+# Convention des cartes Tiled (TMX/TSX)
+
+## Calques attendus
+
+### Calques de tuiles
+- `layer.collision` : masque booléen pour les collisions et les murs infranchissables.
+- `layer.terrain` : terrain jouable principal (coût de déplacement et cover par défaut).
+- `layer.hazard` : surcharges de danger (dégâts de terrain + timing).
+- `layer.cover` : surcharges de couvert (light/heavy/fortification).
+
+### Calques d'objets
+- `objects.props` : décor non bloquant (information purement visuelle).
+- `objects.walls` : volumes bloquant déplacement et ligne de vue.
+- `objects.doors` : volumes ouvrables ; se comportent comme des murs tant qu'ils sont fermés.
+
+## Propriétés de tuiles
+Les propriétés peuvent être définies au niveau du tileset ou d'une tuile individuelle. Les valeurs sont lues dans cet ordre : tuile ➝ tileset ➝ valeurs de repli ci-dessous.
+
+| Propriété         | Type   | Valeurs autorisées                                    | Valeur de repli | Effet gameplay |
+|-------------------|--------|--------------------------------------------------------|-----------------|----------------|
+| `move_cost`       | int    | ≥ 0 (`None` réservé aux murs/void internes)            | `1`             | Coût standard du sol.
+| `blocks_move`     | bool   | `true` / `false`                                       | `false`         | Bloque le déplacement.
+| `blocks_los`      | bool   | `true` / `false`                                       | `false`         | Bloque la ligne de vue.
+| `cover`           | str    | `"none"`, `"light"`, `"heavy"`, `"fortification"`   | `"none"`       | Flags de couvert appliqués.
+| `hazard`          | str    | `"none"`, `"dangerous"`, `"very_dangerous"`        | `"none"`       | Flags + dégâts de terrain.
+| `hazard_timing`   | str    | `"on_enter"`, `"end_of_turn"`, `"per_tile"`        | `"on_enter"`   | Moment d'application des dégâts.
+
+Les valeurs de repli correspondent au terrain « sol » (floor). Elles sont appliquées dès qu'une propriété est absente afin de garantir un état jouable cohérent.
+
+## Unités et coordonnées
+Toutes les conversions se font en coordonnées de grille (cases). Les objets et formes issus de Tiled doivent donc être convertis avant usage gameplay, sans utiliser les pixels comme référence.

--- a/modules/maps/tiled_schema.md
+++ b/modules/maps/tiled_schema.md
@@ -27,5 +27,6 @@ Propriété       | Type | Valeurs autorisées                                | 
 
 Les valeurs de repli correspondent au terrain « sol » (floor). Elles sont appliquées dès qu'une propriété est absente afin de garantir un état jouable cohérent.
 
+> **Note :** Les parseurs traitent les valeurs vides (par exemple, chaîne vide ou espaces) comme « absentes » pour les propriétés `move_cost`, `cover`, `hazard` et `hazard_timing`. Dans ces cas, la valeur de repli est appliquée.
 ## Unités et coordonnées
 Toutes les conversions se font en coordonnées de grille (cases). Les objets et formes issus de Tiled doivent donc être convertis avant usage gameplay, sans utiliser les pixels comme référence.

--- a/modules/maps/tiled_schema.md
+++ b/modules/maps/tiled_schema.md
@@ -16,14 +16,14 @@
 ## Propriétés de tuiles
 Les propriétés peuvent être définies au niveau du tileset ou d'une tuile individuelle. Les valeurs sont lues dans cet ordre : tuile ➝ tileset ➝ valeurs de repli ci-dessous.
 
-| Propriété       | Type | Valeurs autorisées                                | Valeur de repli | Effet gameplay |
-|-----------------|------|----------------------------------------------------|-----------------|----------------|
-| `move_cost`     | int  | ≥ 0 (`None` réservé aux murs/void internes)        | `1`             | Coût standard du sol.
-| `blocks_move`   | bool | `true` / `false`                                   | `false`         | Bloque le déplacement.
-| `blocks_los`    | bool | `true` / `false`                                   | `false`         | Bloque la ligne de vue.
-| `cover`         | str  | `"none"`, `"light"`, `"heavy"`, `"fortification"` | `"none"`       | Flags de couvert appliqués.
-| `hazard`        | str  | `"none"`, `"dangerous"`, `"very_dangerous"`      | `"none"`       | Flags + dégâts de terrain.
-| `hazard_timing` | str  | `"on_enter"`, `"end_of_turn"`, `"per_tile"`      | `"on_enter"`   | Moment d'application des dégâts.
+Propriété       | Type | Valeurs autorisées                                | Valeur de repli | Effet gameplay
+----------------|------|----------------------------------------------------|-----------------|----------------
+`move_cost`     | int  | ≥ 0 (`None` réservé aux murs/void internes)        | `1`             | Coût standard du sol.
+`blocks_move`   | bool | `true` / `false`                                   | `false`         | Bloque le déplacement.
+`blocks_los`    | bool | `true` / `false`                                   | `false`         | Bloque la ligne de vue.
+`cover`         | str  | `"none"`, `"light"`, `"heavy"`, `"fortification"` | `"none"`       | Flags de couvert appliqués.
+`hazard`        | str  | `"none"`, `"dangerous"`, `"very_dangerous"`      | `"none"`       | Flags + dégâts de terrain.
+`hazard_timing` | str  | `"on_enter"`, `"end_of_turn"`, `"per_tile"`      | `"on_enter"`   | Moment d'application des dégâts.
 
 Les valeurs de repli correspondent au terrain « sol » (floor). Elles sont appliquées dès qu'une propriété est absente afin de garantir un état jouable cohérent.
 

--- a/modules/maps/tiled_schema.md
+++ b/modules/maps/tiled_schema.md
@@ -10,7 +10,7 @@
 
 ### Calques d'objets
 - `objects.props` : décor non bloquant (information purement visuelle).
-- `objects.walls` : volumes bloquant déplacement et ligne de vue.
+- `objects.walls` : volumes bloquant le déplacement et la ligne de vue.
 - `objects.doors` : volumes ouvrables ; se comportent comme des murs tant qu'ils sont fermés.
 
 ## Propriétés de tuiles
@@ -19,8 +19,8 @@ Les propriétés peuvent être définies au niveau du tileset ou d'une tuile ind
 Propriété       | Type | Valeurs autorisées                                | Valeur de repli | Effet gameplay
 ----------------|------|----------------------------------------------------|-----------------|----------------
 `move_cost`     | int  | ≥ 0 (`None` réservé aux murs/void internes)        | `1`             | Coût standard du sol.
-`blocks_move`   | bool | `true` / `false`                                   | `false`         | Bloque le déplacement.
-`blocks_los`    | bool | `true` / `false`                                   | `false`         | Bloque la ligne de vue.
+`blocks_move`   | bool | `true` / `false` (`1` / `0`, `yes` / `no`, `on` / `off` acceptés) | `false`         | Bloque le déplacement.
+`blocks_los`    | bool | `true` / `false` (`1` / `0`, `yes` / `no`, `on` / `off` acceptés) | `false`         | Bloque la ligne de vue.
 `cover`         | str  | `"none"`, `"light"`, `"heavy"`, `"fortification"` | `"none"`       | Flags de couvert appliqués.
 `hazard`        | str  | `"none"`, `"dangerous"`, `"very_dangerous"`      | `"none"`       | Flags + dégâts de terrain.
 `hazard_timing` | str  | `"on_enter"`, `"end_of_turn"`, `"per_tile"`      | `"on_enter"`   | Moment d'application des dégâts.

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -71,8 +71,18 @@ _HAZARD_TIMINGS: Final[frozenset[str]] = frozenset(
 
 
 def parse_move_cost(value: Any, *, default: int | None = None) -> int:
-    """Normalise la valeur ``move_cost`` en entier non négatif."""
+    """
+    Normalise la valeur ``move_cost`` en entier non négatif.
 
+    Si ``value`` est ``None``, retourne ``default`` s'il est fourni, sinon
+    ``TILED_DEFAULTS['move_cost']``. Les chaînes vides sont traitées comme
+    absentes et déclenchent également la valeur par défaut.
+
+    :param value: Valeur à normaliser (int, float, str, ou None).
+    :param default: Valeur de repli à utiliser si ``value`` est ``None``.
+    :return: Un entier non négatif représentant le coût de déplacement.
+    :raises ValueError: Si la valeur n'est pas un nombre entier non négatif.
+    """
     if value is None:
         if default is not None:
             return parse_move_cost(default, default=None)

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -159,7 +159,8 @@ def parse_hazard_timing(value: Any) -> HazardTiming:
     if not timing:
         return HAZARD_DEFAULT_TIMING
     if timing not in _HAZARD_TIMINGS:
-        raise ValueError(f"hazard_timing inconnu: {value!r}")
+        expected = ", ".join(sorted(_HAZARD_TIMINGS))
+        raise ValueError(f"hazard_timing inconnu: {value!r} (attendu: {expected})")
     return cast(HazardTiming, timing)
 
 

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -165,9 +165,9 @@ def parse_hazard_timing(value: Any) -> HazardTiming:
 def apply_tile_defaults(properties: Mapping[str, Any]) -> dict[str, Any]:
     """Retourne un dict de propriétés complété avec les valeurs de repli."""
 
-    resolved: dict[str, Any] = {}
+    resolved: dict[str, Any] = dict(properties)
     for key, default_value in TILED_DEFAULTS.items():
-        resolved[key] = properties.get(key, default_value)
+        resolved.setdefault(key, default_value)
     return resolved
 
 

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -147,7 +147,8 @@ def parse_hazard_str(value: Any) -> tuple[TerrainFlags, int]:
     try:
         return _HAZARD_SPECS[key]
     except KeyError as exc:
-        raise ValueError(f"hazard inconnu: {value!r}") from exc
+        valid = ', '.join(sorted(_HAZARD_SPECS))
+        raise ValueError(f"hazard inconnu: {value!r} (attendu: {valid})") from exc
 
 
 def parse_hazard_timing(value: Any) -> HazardTiming:

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -131,7 +131,8 @@ def parse_cover_str(value: Any) -> TerrainFlags:
     try:
         return _COVER_FLAGS[key]
     except KeyError as exc:
-        raise ValueError(f"cover inconnu: {value!r}") from exc
+        valid = ", ".join(sorted(_COVER_FLAGS))
+        raise ValueError(f"cover inconnu: {value!r} (attendu: {valid})") from exc
 
 
 def parse_hazard_str(value: Any) -> tuple[TerrainFlags, int]:

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -42,8 +42,8 @@ TILED_DEFAULTS: Final[dict[str, Any]] = {
 }
 
 
-_BOOL_TRUE = {"1", "true", "yes", "on"}
-_BOOL_FALSE = {"0", "false", "no", "off"}
+_BOOL_TRUE: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+_BOOL_FALSE: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
 
 _COVER_FLAGS: Final[dict[str, TerrainFlags]] = {
     "none": TerrainFlags(0),

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -113,7 +113,10 @@ def parse_bool_flag(value: Any, *, default: bool) -> bool:
         return True
     if value_str in _BOOL_FALSE:
         return False
-    raise ValueError(f"valeur booléenne invalide: {value!r}")
+    expected = ", ".join(sorted(_BOOL_TRUE | _BOOL_FALSE))
+    raise ValueError(
+        f"valeur booléenne invalide: {value!r} (attendu: {expected})"
+    )
 
 
 def parse_cover_str(value: Any) -> TerrainFlags:

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -61,11 +61,11 @@ _HAZARD_SPECS: Final[dict[str, tuple[TerrainFlags, int]]] = {
     ),
 }
 
-_HAZARD_TIMINGS: Final[frozenset[HazardTiming]] = frozenset(
+_HAZARD_TIMINGS: Final[frozenset[str]] = frozenset(
     {
-        cast(HazardTiming, "on_enter"),
-        cast(HazardTiming, "end_of_turn"),
-        cast(HazardTiming, "per_tile"),
+        "on_enter",
+        "end_of_turn",
+        "per_tile",
     }
 )
 

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -1,0 +1,163 @@
+"""Conventions partagées pour la lecture des cartes Tiled (TMX/TSX)."""
+from __future__ import annotations
+
+from typing import Any, Final, Mapping
+
+from modules.maps.terrain_types import HazardTiming, TerrainFlags
+
+
+TILED_KEYS: Final[dict[str, Mapping[str, str]]] = {
+    "tile_layers": {
+        "collision": "layer.collision",
+        "terrain": "layer.terrain",
+        "hazard": "layer.hazard",
+        "cover": "layer.cover",
+    },
+    "object_layers": {
+        "props": "objects.props",
+        "walls": "objects.walls",
+        "doors": "objects.doors",
+    },
+    "properties": {
+        "move_cost": "move_cost",
+        "blocks_move": "blocks_move",
+        "blocks_los": "blocks_los",
+        "cover": "cover",
+        "hazard": "hazard",
+        "hazard_timing": "hazard_timing",
+    },
+}
+
+TILED_DEFAULTS: Final[dict[str, Any]] = {
+    "move_cost": 1,
+    "blocks_move": False,
+    "blocks_los": False,
+    "cover": "none",
+    "hazard": "none",
+    "hazard_timing": "on_enter",
+}
+
+
+_BOOL_TRUE = {"1", "true", "yes", "on"}
+_BOOL_FALSE = {"0", "false", "no", "off"}
+
+_COVER_FLAGS: Final[dict[str, TerrainFlags]] = {
+    "none": TerrainFlags(0),
+    "light": TerrainFlags.COVER_LIGHT,
+    "heavy": TerrainFlags.COVER_HEAVY,
+    "fortification": TerrainFlags.COVER_HEAVY | TerrainFlags.FORTIFICATION,
+}
+
+_HAZARD_SPECS: Final[dict[str, tuple[TerrainFlags, int]]] = {
+    "none": (TerrainFlags(0), 0),
+    "dangerous": (TerrainFlags.HAZARDOUS, 5),
+    "very_dangerous": (
+        TerrainFlags.HAZARDOUS | TerrainFlags.VERY_HAZARDOUS,
+        10,
+    ),
+}
+
+_HAZARD_TIMINGS: Final[set[HazardTiming]] = {"on_enter", "end_of_turn", "per_tile"}
+
+
+def parse_move_cost(value: Any, *, default: int | None = None) -> int:
+    """Normalise la valeur ``move_cost`` en entier positif."""
+
+    if value is None:
+        if default is not None:
+            return parse_move_cost(default, default=None)
+        return TILED_DEFAULTS["move_cost"]
+
+    if isinstance(value, bool):
+        raise ValueError("move_cost ne peut pas être un booléen")
+
+    if isinstance(value, (int, float)):
+        cost = int(value)
+    else:
+        value_str = str(value).strip()
+        if not value_str:
+            return TILED_DEFAULTS["move_cost"]
+        cost = int(value_str)
+
+    if cost < 0:
+        raise ValueError("move_cost doit être >= 0")
+    return cost
+
+
+def parse_bool_flag(value: Any, *, default: bool) -> bool:
+    """Convertit une propriété booléenne Tiled en bool Python."""
+
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    value_str = str(value).strip().lower()
+    if value_str in _BOOL_TRUE:
+        return True
+    if value_str in _BOOL_FALSE:
+        return False
+    raise ValueError(f"valeur booléenne invalide: {value!r}")
+
+
+def parse_cover_str(value: Any) -> TerrainFlags:
+    """Mappe la propriété ``cover`` vers les :class:`TerrainFlags` correspondants."""
+
+    if value is None:
+        key = "none"
+    else:
+        key = str(value).strip().lower()
+        if not key:
+            key = "none"
+    try:
+        return _COVER_FLAGS[key]
+    except KeyError as exc:
+        raise ValueError(f"cover inconnu: {value!r}") from exc
+
+
+def parse_hazard_str(value: Any) -> tuple[TerrainFlags, int]:
+    """Mappe la propriété ``hazard`` vers flags + dégâts."""
+
+    if value is None:
+        key = "none"
+    else:
+        key = str(value).strip().lower()
+        if not key:
+            key = "none"
+    try:
+        return _HAZARD_SPECS[key]
+    except KeyError as exc:
+        raise ValueError(f"hazard inconnu: {value!r}") from exc
+
+
+def parse_hazard_timing(value: Any) -> HazardTiming:
+    """Valide la propriété ``hazard_timing`` et retourne le libellé normalisé."""
+
+    if value is None:
+        return TILED_DEFAULTS["hazard_timing"]
+    timing = str(value).strip().lower()
+    if not timing:
+        return TILED_DEFAULTS["hazard_timing"]
+    if timing not in _HAZARD_TIMINGS:
+        raise ValueError(f"hazard_timing inconnu: {value!r}")
+    return timing  # type: ignore[return-value]
+
+
+def apply_tile_defaults(properties: Mapping[str, Any]) -> dict[str, Any]:
+    """Retourne un dict de propriétés complété avec les valeurs de repli."""
+
+    resolved: dict[str, Any] = {}
+    for key, default_value in TILED_DEFAULTS.items():
+        resolved[key] = properties.get(key, default_value)
+    return resolved
+
+
+__all__ = [
+    "TILED_KEYS",
+    "TILED_DEFAULTS",
+    "parse_move_cost",
+    "parse_bool_flag",
+    "parse_cover_str",
+    "parse_hazard_str",
+    "parse_hazard_timing",
+    "apply_tile_defaults",
+]

--- a/modules/maps/tiled_schema.py
+++ b/modules/maps/tiled_schema.py
@@ -147,7 +147,7 @@ def parse_hazard_str(value: Any) -> tuple[TerrainFlags, int]:
     try:
         return _HAZARD_SPECS[key]
     except KeyError as exc:
-        valid = ', '.join(sorted(_HAZARD_SPECS))
+        valid = ", ".join(sorted(_HAZARD_SPECS))
         raise ValueError(f"hazard inconnu: {value!r} (attendu: {valid})") from exc
 
 


### PR DESCRIPTION
## Summary
- document the agreed layers and tile properties for Tiled maps, including default fallbacks
- add reusable schema constants and parsing helpers to translate cover and hazard properties into engine flags
- include the source path in map JSON decode errors to satisfy the schema validation tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1a9cfc62c832dbaa92c8d9f425a74