### PR TITLE
Add event-driven map loading system

### DIFF
--- a/assets/maps/test.tmx
+++ b/assets/maps/test.tmx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.9" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1">
+ <properties>
+  <property name="name" value="Test Map"/>
+  <property name="biome" value="test_biome"/>
+ </properties>
+ <layer id="1" name="layer.terrain" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+  </data>
+ </layer>
+</map>

--- a/modules/maps/events.py
+++ b/modules/maps/events.py
@@ -1,0 +1,59 @@
+"""Event definitions for map loading and activation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Protocol, runtime_checkable
+
+from modules.maps.components import MapMeta
+
+
+LOAD_MAP_FROM_TILED = "maps.load_from_tiled"
+"""Event topic requesting a TMX map to be imported into the ECS."""
+
+MAP_LOADED = "maps.loaded"
+"""Event topic emitted when a map entity has been created."""
+
+
+@runtime_checkable
+class _PublishesEvents(Protocol):
+    """Protocol capturing the subset of the event bus used here."""
+
+    def publish(self, event_type: str, **payload: object) -> None:
+        """Publish an event to all subscribers."""
+
+
+@dataclass(frozen=True, slots=True)
+class LoadMapFromTiled:
+    """Request loading of a Tiled TMX map into the ECS."""
+
+    path: str
+
+    topic: ClassVar[str] = LOAD_MAP_FROM_TILED
+
+    def publish(self, bus: _PublishesEvents) -> None:
+        """Convenience helper mirroring ``EventBus.publish``."""
+
+        bus.publish(self.topic, path=self.path)
+
+
+@dataclass(frozen=True, slots=True)
+class MapLoaded:
+    """Notification emitted once a map entity is available in the ECS."""
+
+    map_entity_id: str
+    meta: MapMeta
+
+    topic: ClassVar[str] = MAP_LOADED
+
+    def publish(self, bus: _PublishesEvents) -> None:
+        """Convenience helper mirroring ``EventBus.publish``."""
+
+        bus.publish(self.topic, map_entity_id=self.map_entity_id, meta=self.meta)
+
+
+__all__ = [
+    "LoadMapFromTiled",
+    "MapLoaded",
+    "MAP_LOADED",
+    "LOAD_MAP_FROM_TILED",
+]

--- a/modules/maps/systems/map_loader.py
+++ b/modules/maps/systems/map_loader.py
@@ -1,0 +1,125 @@
+"""Event-driven system responsible for importing maps into the ECS."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional, Protocol
+
+from ecs.components.entity_id import EntityIdComponent
+from modules.maps.components import MapComponent, MapMeta
+from modules.maps.events import LoadMapFromTiled, MapLoaded
+from modules.maps.spec import to_map_component
+from modules.maps.tiled_importer import TiledImporter
+
+
+class _EventBus(Protocol):
+    """Subset of the event bus interface required by :class:`MapLoaderSystem`."""
+
+    def subscribe(self, event_type: str, callback: Callable[..., None]) -> None:
+        ...
+
+    def publish(self, event_type: str, **payload: object) -> None:
+        ...
+
+
+class MapLoaderSystem:
+    """Listen for :class:`LoadMapFromTiled` requests and create map entities."""
+
+    def __init__(
+        self,
+        ecs_manager: "ECSManager",
+        *,
+        event_bus: _EventBus,
+        importer: Optional[TiledImporter] = None,
+    ) -> None:
+        self._ecs = ecs_manager
+        self._bus = event_bus
+        self._importer = importer or TiledImporter()
+        self._active_internal_id: Optional[int] = None
+        self._active_entity_id: Optional[str] = None
+
+        self._bus.subscribe(LoadMapFromTiled.topic, self._on_load_requested)
+
+    # ------------------------------------------------------------------
+    def _on_load_requested(self, *, path: str, **_: object) -> None:
+        spec = self._importer.load(path)
+        map_component = to_map_component(spec)
+
+        self._despawn_active_map()
+
+        entity_id = self._derive_entity_id(spec.meta, path)
+        internal_id = self._ecs.create_entity(
+            EntityIdComponent(entity_id),
+            map_component,
+        )
+        self._active_internal_id = internal_id
+        self._active_entity_id = entity_id
+
+        MapLoaded(map_entity_id=entity_id, meta=map_component.meta).publish(self._bus)
+
+    def _despawn_active_map(self) -> None:
+        if self._active_internal_id is None:
+            return
+        self._ecs.delete_entity(self._active_internal_id)
+        self._active_internal_id = None
+        self._active_entity_id = None
+
+    def _derive_entity_id(self, meta: MapMeta, path: str) -> str:
+        base = self._normalise_identifier(meta.name)
+        if not base:
+            base = self._normalise_identifier(Path(path).stem)
+        if not base:
+            base = "map"
+
+        candidate = f"map:{base}"
+        suffix = 1
+        while True:
+            existing = self._ecs.resolve_entity(candidate)
+            if existing is None:
+                break
+            suffix += 1
+            candidate = f"map:{base}:{suffix}"
+        return candidate
+
+    @staticmethod
+    def _normalise_identifier(raw: str | None) -> str:
+        if not raw:
+            return ""
+        lowered = raw.lower()
+        normalised = [
+            ch if ch.isalnum() else "_"
+            for ch in lowered
+        ]
+        collapsed = "".join(normalised).strip("_")
+        while "__" in collapsed:
+            collapsed = collapsed.replace("__", "_")
+        return collapsed
+
+    # Public API -------------------------------------------------------
+    def get_active_map(self) -> tuple[str, MapComponent]:
+        """Return the active map entity id and component."""
+
+        if self._active_entity_id is None:
+            raise LookupError("No active map has been loaded.")
+
+        component = self._ecs.get_component_for_entity(self._active_entity_id, MapComponent)
+        if component is None:
+            raise LookupError("Active map component is missing from the ECS.")
+        return self._active_entity_id, component
+
+
+def get_active_map(ecs_manager: "ECSManager") -> tuple[str, MapComponent]:
+    """Helper that queries the ECS for the single active map component."""
+
+    candidates = list(ecs_manager.iter_with_id(MapComponent))
+    if not candidates:
+        raise LookupError("No map entities are currently registered in the ECS.")
+    if len(candidates) > 1:
+        raise LookupError("Multiple map entities detected; cannot determine the active map.")
+    entity_id, component = candidates[0]
+    return entity_id, component
+
+
+__all__ = [
+    "MapLoaderSystem",
+    "get_active_map",
+]

--- a/tests/unit/test_map_loader_system.py
+++ b/tests/unit/test_map_loader_system.py
@@ -1,0 +1,44 @@
+from core.event_bus import EventBus
+from ecs.ecs_manager import ECSManager
+from modules.maps.components import MapComponent, MapMeta
+from modules.maps.events import MAP_LOADED, LoadMapFromTiled
+from modules.maps.systems.map_loader import MapLoaderSystem, get_active_map
+
+
+def test_load_map_from_tiled_creates_entity_and_emits_event():
+    bus = EventBus()
+    ecs_manager = ECSManager(event_bus=bus)
+    loader = MapLoaderSystem(ecs_manager, event_bus=bus)
+
+    captured: dict[str, object] = {}
+
+    def _on_map_loaded(*, map_entity_id: str, meta: MapMeta, **_: object) -> None:
+        captured["map_entity_id"] = map_entity_id
+        captured["meta"] = meta
+
+    bus.subscribe(MAP_LOADED, _on_map_loaded)
+
+    LoadMapFromTiled("assets/maps/test.tmx").publish(bus)
+
+    assert "map_entity_id" in captured
+    assert "meta" in captured
+
+    entity_id = captured["map_entity_id"]
+    meta = captured["meta"]
+
+    assert isinstance(entity_id, str)
+    assert meta.name == "Test Map"
+    assert meta.biome == "test_biome"
+
+    component = ecs_manager.get_component_for_entity(entity_id, MapComponent)
+    assert isinstance(component, MapComponent)
+    assert component.grid.width == 2
+    assert component.grid.height == 2
+
+    active_id, active_component = loader.get_active_map()
+    assert active_id == entity_id
+    assert active_component is component
+
+    helper_id, helper_component = get_active_map(ecs_manager)
+    assert helper_id == entity_id
+    assert helper_component is component


### PR DESCRIPTION
## Summary
- define map loader events for requesting TMX imports and announcing created map entities
- implement an event-driven map loader system that spawns the active map entity and exposes helpers
- add a TMX fixture and unit test covering end-to-end loading and activation

## Testing
- pytest tests/unit/test_map_loader_system.py

------
https://chatgpt.com/codex/tasks/task_e_68e2764d62bc832da3ecc20698a60ceb