### PR TITLE
Support multi-tile spawn footprints and widen testing

### DIFF
--- a/modules/maps/components.py
+++ b/modules/maps/components.py
@@ -1,8 +1,8 @@
 """Map-related ECS components and supporting data structures."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import List, TypeVar, Union
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, TypeVar, Union
 
 from modules.maps.terrain_types import TerrainDescriptor, TerrainFlags
 
@@ -122,6 +122,7 @@ class MapMeta:
     name: str
     biome: str
     seed: int | None = None
+    spawn_zones: Dict[str, SpawnZone] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -132,5 +133,28 @@ class MapComponent:
     meta: MapMeta
 
 
-__all__ = ["MapGrid", "MapMeta", "MapComponent"]
+__all__ = ["MapGrid", "MapMeta", "MapComponent", "SpawnZone"]
+
+@dataclass(slots=True)
+class SpawnZone:
+    """Represents a deployment area used as a spawn location."""
+
+    label: str
+    position: Tuple[int, int]
+    footprint: Tuple[int, int] = (1, 1)
+    safe_radius: int = 1
+    allow_decor: bool = False
+    allow_hazard: bool = False
+
+    def clone(self) -> "SpawnZone":
+        """Return a shallow copy of the spawn zone."""
+
+        return SpawnZone(
+            label=self.label,
+            position=self.position,
+            footprint=self.footprint,
+            safe_radius=self.safe_radius,
+            allow_decor=self.allow_decor,
+            allow_hazard=self.allow_hazard,
+        )
 

--- a/modules/maps/gen/spawns.py
+++ b/modules/maps/gen/spawns.py
@@ -1,0 +1,389 @@
+"""Spawn zone selection for generated maps."""
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable, List, Sequence, Tuple
+
+from core.pathfinding_optimization import OptimizedPathfinding
+from modules.maps.components import SpawnZone
+from modules.maps.spec import MapSpec, to_map_component
+from modules.maps.terrain_types import TerrainFlags
+
+
+_CARDINALS: Sequence[Tuple[int, int]] = ((1, 0), (-1, 0), (0, 1), (0, -1))
+_CHEB_NEIGHBOURHOOD: Sequence[Tuple[int, int]] = (
+    (-1, -1),
+    (-1, 0),
+    (-1, 1),
+    (0, -1),
+    (0, 0),
+    (0, 1),
+    (1, -1),
+    (1, 0),
+    (1, 1),
+)
+_FAIRNESS_THRESHOLD = 0.05
+_FORBIDDEN_FLAGS = (
+    TerrainFlags.COVER_LIGHT
+    | TerrainFlags.COVER_HEAVY
+    | TerrainFlags.FORTIFICATION
+    | TerrainFlags.DIFFICULT
+    | TerrainFlags.VERY_DIFFICULT
+    | TerrainFlags.HAZARDOUS
+    | TerrainFlags.VERY_HAZARDOUS
+)
+
+
+class _SpawnTerrain:
+    """Minimal terrain adapter used for pathfinding distance checks."""
+
+    def __init__(self, grid) -> None:
+        self.width = grid.width
+        self.height = grid.height
+        wall_list: List[Tuple[int, int]] = []
+        for y in range(self.height):
+            for x in range(self.width):
+                if grid.blocks_move_mask[y][x]:
+                    wall_list.append((x, y))
+        self.walls = set(wall_list)
+        self.path_cache = None
+        self.reachable_tiles_cache = None
+
+    def is_walkable(self, x: int, y: int) -> bool:
+        return 0 <= x < self.width and 0 <= y < self.height and (x, y) not in self.walls
+
+
+def _is_walkable(grid, x: int, y: int) -> bool:
+    return 0 <= x < grid.width and 0 <= y < grid.height and not grid.blocks_move_mask[y][x]
+
+
+def _is_safe_area(
+    grid,
+    x: int,
+    y: int,
+    footprint: Tuple[int, int],
+    clearance: int,
+) -> bool:
+    width, height = footprint
+    if width <= 0 or height <= 0:
+        return False
+    if x < clearance or y < clearance:
+        return False
+    if x + width + clearance > grid.width:
+        return False
+    if y + height + clearance > grid.height:
+        return False
+
+    for ny in range(y - clearance, y + height + clearance):
+        for nx in range(x - clearance, x + width + clearance):
+            if not _is_walkable(grid, nx, ny):
+                return False
+            flags = TerrainFlags(grid.flags[ny][nx])
+            if flags & _FORBIDDEN_FLAGS:
+                return False
+            if grid.hazard_damage[ny][nx] > 0:
+                return False
+    return True
+
+
+def _collect_candidates(
+    grid,
+    footprint: Tuple[int, int],
+    clearance: int,
+) -> List[Tuple[int, int]]:
+    width, height = footprint
+    candidates: List[Tuple[int, int]] = []
+    max_x = grid.width - width - clearance + 1
+    max_y = grid.height - height - clearance + 1
+    if max_x <= clearance or max_y <= clearance:
+        return candidates
+    for y in range(clearance, max_y):
+        for x in range(clearance, max_x):
+            if _is_safe_area(grid, x, y, footprint, clearance):
+                candidates.append((x, y))
+    return candidates
+
+
+def _bfs_distances(grid, start: Tuple[int, int]) -> dict[Tuple[int, int], int]:
+    queue: deque[Tuple[int, int]] = deque([start])
+    distances: dict[Tuple[int, int], int] = {start: 0}
+    while queue:
+        x, y = queue.popleft()
+        base_dist = distances[(x, y)]
+        for dx, dy in _CARDINALS:
+            nx, ny = x + dx, y + dy
+            if not _is_walkable(grid, nx, ny):
+                continue
+            if (nx, ny) in distances:
+                continue
+            distances[(nx, ny)] = base_dist + 1
+            queue.append((nx, ny))
+    return distances
+
+
+def _pick_spawn_pair(
+    candidates: List[Tuple[int, int]],
+    grid,
+    pois: Sequence[Tuple[int, int]],
+    optimizer: OptimizedPathfinding,
+    footprint: Tuple[int, int],
+) -> tuple[List[Tuple[int, int]], float]:
+    if len(candidates) < 2:
+        return (candidates[:], float("inf"))
+    best_pair: tuple[Tuple[int, int], Tuple[int, int]] | None = None
+    best_distance = -1
+    best_ratio = float("inf")
+    distance_cache: dict[Tuple[int, int], dict[Tuple[int, int], int]] = {}
+    for idx, start in enumerate(candidates[:-1]):
+        dist_map = distance_cache.setdefault(start, _bfs_distances(grid, start))
+        for other in candidates[idx + 1 :]:
+            pair_distance = dist_map.get(other)
+            if pair_distance is None:
+                continue
+            ratio = _fairness_ratio(
+                optimizer,
+                [start, other],
+                pois,
+                footprint,
+            )
+            if ratio <= _FAIRNESS_THRESHOLD:
+                if pair_distance > best_distance or best_pair is None:
+                    best_distance = pair_distance
+                    best_ratio = ratio
+                    best_pair = (start, other)
+            elif best_pair is None or ratio < best_ratio:
+                best_pair = (start, other)
+                best_distance = pair_distance
+                best_ratio = ratio
+    if best_pair is None:
+        best_pair = (candidates[0], candidates[1])
+    return [best_pair[0], best_pair[1]], best_ratio
+
+
+def _nearest_walkable(grid, target: Tuple[int, int]) -> Tuple[int, int] | None:
+    tx, ty = target
+    if _is_walkable(grid, tx, ty):
+        return target
+    queue: deque[Tuple[int, int]] = deque([target])
+    seen = {target}
+    while queue:
+        x, y = queue.popleft()
+        for dx, dy in _CHEB_NEIGHBOURHOOD:
+            nx, ny = x + dx, y + dy
+            if not (0 <= nx < grid.width and 0 <= ny < grid.height):
+                continue
+            if (nx, ny) in seen:
+                continue
+            seen.add((nx, ny))
+            if _is_walkable(grid, nx, ny):
+                return (nx, ny)
+            queue.append((nx, ny))
+    return None
+
+
+def _determine_pois(grid) -> List[Tuple[int, int]]:
+    width, height = grid.width, grid.height
+    raw_points = {
+        (width // 2, height // 2),
+        (width // 4, height // 2),
+        (3 * width // 4, height // 2),
+        (width // 2, height // 4),
+        (width // 2, 3 * height // 4),
+    }
+    pois: List[Tuple[int, int]] = []
+    for point in raw_points:
+        candidate = _nearest_walkable(grid, point)
+        if candidate is not None and candidate not in pois:
+            pois.append(candidate)
+    return pois
+
+
+def _path_length(optimizer: OptimizedPathfinding, start: Tuple[int, int], end: Tuple[int, int]) -> float:
+    if start == end:
+        return 0.0
+    path = optimizer._compute_path_astar(start, end)
+    if not path:
+        return float("inf")
+    return float(len(path) - 1)
+
+
+def _spawn_cells(position: Tuple[int, int], footprint: Tuple[int, int]) -> List[Tuple[int, int]]:
+    x, y = position
+    width, height = footprint
+    return [
+        (x + dx, y + dy)
+        for dy in range(height)
+        for dx in range(width)
+    ]
+
+
+def _spawn_distance(
+    optimizer: OptimizedPathfinding,
+    position: Tuple[int, int],
+    footprint: Tuple[int, int],
+    poi: Tuple[int, int],
+) -> float:
+    best = float("inf")
+    for cell in _spawn_cells(position, footprint):
+        length = _path_length(optimizer, cell, poi)
+        if length < best:
+            best = length
+    return best
+
+
+def _fairness_ratio(
+    optimizer: OptimizedPathfinding,
+    spawns: Sequence[SpawnZone | Tuple[int, int]],
+    pois: Sequence[Tuple[int, int]],
+    footprint: Tuple[int, int] = (1, 1),
+) -> float:
+    spawn_infos: List[Tuple[Tuple[int, int], Tuple[int, int]]] = []
+    for spawn in spawns:
+        if hasattr(spawn, "position") and hasattr(spawn, "footprint"):
+            spawn_infos.append((spawn.position, spawn.footprint))
+        else:
+            spawn_infos.append((spawn, footprint))
+
+    worst = 0.0
+    for poi in pois:
+        distances: List[float] = []
+        unreachable = False
+        for position, spawn_footprint in spawn_infos:
+            length = _spawn_distance(optimizer, position, spawn_footprint, poi)
+            if length == float("inf"):
+                unreachable = True
+                break
+            distances.append(length)
+        if unreachable or not distances:
+            continue
+        avg = sum(distances) / len(distances)
+        if avg == 0:
+            continue
+        delta = max(distances) - min(distances)
+        worst = max(worst, delta / avg)
+    return worst
+
+
+def _neighbourhood_candidates(
+    center: Tuple[int, int],
+    candidates: set[Tuple[int, int]],
+    radius: int,
+) -> Iterable[Tuple[int, int]]:
+    cx, cy = center
+    for dx in range(-radius, radius + 1):
+        for dy in range(-radius, radius + 1):
+            nx, ny = cx + dx, cy + dy
+            if abs(dx) + abs(dy) > radius:
+                continue
+            coord = (nx, ny)
+            if coord in candidates:
+                yield coord
+
+
+def _improve_fairness(
+    optimizer: OptimizedPathfinding,
+    spawns: List[Tuple[int, int]],
+    pois: Sequence[Tuple[int, int]],
+    candidates: set[Tuple[int, int]],
+    footprint: Tuple[int, int],
+) -> List[Tuple[int, int]]:
+    if not candidates:
+        return list(spawns)
+
+    best = list(spawns)
+    best_ratio = _fairness_ratio(optimizer, best, pois, footprint)
+    if best_ratio <= _FAIRNESS_THRESHOLD:
+        return best
+    max_iterations = 12
+    for _ in range(max_iterations):
+        improved = False
+        for idx, position in enumerate(list(best)):
+            for candidate in _neighbourhood_candidates(position, candidates, radius=4):
+                if candidate == position:
+                    continue
+                if candidate in best:
+                    continue
+                trial = list(best)
+                trial[idx] = candidate
+                ratio = _fairness_ratio(optimizer, trial, pois, footprint)
+                if ratio < best_ratio:
+                    best = trial
+                    best_ratio = ratio
+                    improved = True
+                    break
+            if improved and best_ratio <= _FAIRNESS_THRESHOLD:
+                return best
+        if not improved:
+            break
+    return best
+
+
+def assign_spawn_zones(
+    spec: MapSpec,
+    max_spawns: int = 2,
+    *,
+    footprint: Tuple[int, int] = (1, 1),
+    clearance: int = 1,
+    enforce_fairness: bool = True,
+) -> MapSpec:
+    """Assign spawn zones to ``spec`` ensuring fairness and safety constraints."""
+
+    if max_spawns < 2:
+        raise ValueError("at least two spawn zones are required")
+    width, height = footprint
+    if width <= 0 or height <= 0:
+        raise ValueError("footprint dimensions must be positive")
+    clearance = max(0, clearance)
+
+    component = to_map_component(spec)
+    grid = component.grid
+
+    safe_clearance = clearance
+    candidates = _collect_candidates(grid, footprint, safe_clearance)
+    allow_decor = False
+    if len(candidates) < max_spawns:
+        safe_clearance = 0
+        candidates = _collect_candidates(grid, footprint, safe_clearance)
+        allow_decor = True
+    if len(candidates) < max_spawns:
+        raise RuntimeError("unable to place spawn zones: insufficient safe tiles")
+
+    terrain = _SpawnTerrain(grid)
+    optimizer = OptimizedPathfinding(terrain)
+    optimizer.min_region_size = max(8, min(grid.width, grid.height) // 2)
+    optimizer.precompute_paths()
+
+    pois = _determine_pois(grid)
+    spawn_positions, _ = _pick_spawn_pair(candidates, grid, pois, optimizer, footprint)
+    spawn_positions = spawn_positions[:max_spawns]
+    if len(spawn_positions) < max_spawns:
+        remaining = [coord for coord in candidates if coord not in spawn_positions]
+        spawn_positions.extend(remaining[: max_spawns - len(spawn_positions)])
+    spawn_positions = _improve_fairness(
+        optimizer,
+        spawn_positions,
+        pois,
+        set(candidates),
+        footprint,
+    )
+    ratio = _fairness_ratio(optimizer, spawn_positions, pois, footprint)
+    if enforce_fairness and ratio > _FAIRNESS_THRESHOLD:
+        raise RuntimeError("failed to produce fair spawn distribution")
+
+    labels = ["spawn_A", "spawn_B", "spawn_C", "spawn_D"]
+    zones = {
+        label: SpawnZone(
+            label=label,
+            position=position,
+            footprint=footprint,
+            safe_radius=safe_clearance,
+            allow_decor=allow_decor,
+            allow_hazard=False,
+        )
+        for label, position in zip(labels, spawn_positions)
+    }
+    spec.meta.spawn_zones = zones
+    return spec
+
+
+__all__ = ["assign_spawn_zones"]

--- a/modules/maps/gen/validate.py
+++ b/modules/maps/gen/validate.py
@@ -1,0 +1,311 @@
+"""Validation and fix-ups for procedurally generated maps."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Callable, List, Sequence, Set, Tuple
+
+from modules.maps.spec import MapSpec, to_map_component
+
+
+@dataclass(slots=True)
+class ValidationResult:
+    valid: bool
+    fixed: bool
+
+
+_CARDINALS: Tuple[Tuple[int, int], ...] = ((1, 0), (-1, 0), (0, 1), (0, -1))
+
+
+class MapValidator:
+    """Validate maps for connectivity and chokepoint resilience."""
+
+    def __init__(self, spec: MapSpec) -> None:
+        self.spec = spec
+        self._refresh()
+
+    def _refresh(self) -> None:
+        component = to_map_component(self.spec)
+        self.grid = component.grid
+        self.width = self.grid.width
+        self.height = self.grid.height
+
+    def is_valid(self) -> bool:
+        if len(self._connected_components()) > 1:
+            return False
+        return self._has_min_cut(2)
+
+    def validate(self) -> ValidationResult:
+        components = self._connected_components()
+        if len(components) > 1:
+            if self._fix_connectivity(components):
+                self._refresh()
+                return ValidationResult(valid=False, fixed=True)
+            return ValidationResult(valid=False, fixed=False)
+
+        if not self._has_min_cut(2):
+            if self._fix_chokepoints():
+                self._refresh()
+                return ValidationResult(valid=False, fixed=True)
+            return ValidationResult(valid=False, fixed=False)
+
+        return ValidationResult(valid=True, fixed=False)
+
+    def _connected_components(self) -> List[Set[Tuple[int, int]]]:
+        visited: Set[Tuple[int, int]] = set()
+        components: List[Set[Tuple[int, int]]] = []
+        for y in range(self.height):
+            for x in range(self.width):
+                if self.grid.blocks_move_mask[y][x]:
+                    continue
+                coord = (x, y)
+                if coord in visited:
+                    continue
+                component = self._flood_fill(coord, visited)
+                components.append(component)
+        return components
+
+    def _flood_fill(
+        self,
+        start: Tuple[int, int],
+        visited: Set[Tuple[int, int]],
+    ) -> Set[Tuple[int, int]]:
+        queue: deque[Tuple[int, int]] = deque([start])
+        component: Set[Tuple[int, int]] = set([start])
+        visited.add(start)
+        while queue:
+            x, y = queue.popleft()
+            for dx, dy in _CARDINALS:
+                nx, ny = x + dx, y + dy
+                neighbour = (nx, ny)
+                if not self._is_walkable(nx, ny):
+                    continue
+                if neighbour in visited:
+                    continue
+                visited.add(neighbour)
+                component.add(neighbour)
+                queue.append(neighbour)
+        return component
+
+    def _is_walkable(self, x: int, y: int) -> bool:
+        return 0 <= x < self.width and 0 <= y < self.height and not self.grid.blocks_move_mask[y][x]
+
+    def _set_floor(self, x: int, y: int) -> None:
+        if 0 <= x < self.spec.width and 0 <= y < self.spec.height:
+            self.spec.cells[y][x] = "floor"
+
+    def _fix_connectivity(self, components: Sequence[Set[Tuple[int, int]]]) -> bool:
+        if len(components) <= 1:
+            return False
+        base = max(components, key=len)
+        others = [comp for comp in components if comp is not base]
+        for comp in others:
+            if self._bridge_components(base, comp):
+                return True
+        return False
+
+    def _bridge_components(
+        self,
+        base: Set[Tuple[int, int]],
+        other: Set[Tuple[int, int]],
+    ) -> bool:
+        # Attempt direct bridge by widening wall between adjacent components.
+        for x, y in other:
+            for dx, dy in _CARDINALS:
+                wx, wy = x + dx, y + dy
+                tx, ty = x + 2 * dx, y + 2 * dy
+                if not (0 <= wx < self.width and 0 <= wy < self.height):
+                    continue
+                if not (0 <= tx < self.width and 0 <= ty < self.height):
+                    continue
+                if (tx, ty) not in base:
+                    continue
+                if not self.grid.blocks_move_mask[wy][wx]:
+                    continue
+                self._set_floor(wx, wy)
+                return True
+        # Fallback: carve a Manhattan corridor between closest cells.
+        closest_pair = None
+        best_distance = None
+        for bx, by in base:
+            for ox, oy in other:
+                distance = abs(bx - ox) + abs(by - oy)
+                if best_distance is None or distance < best_distance:
+                    best_distance = distance
+                    closest_pair = ((bx, by), (ox, oy))
+        if closest_pair is None:
+            return False
+        (bx, by), (ox, oy) = closest_pair
+        x, y = ox, oy
+        while x != bx:
+            x += 1 if bx > x else -1
+            self._set_floor(x, y)
+        while y != by:
+            y += 1 if by > y else -1
+            self._set_floor(x, y)
+        return True
+
+    def _spawn_positions(self) -> List[Tuple[int, int]]:
+        zones = self.spec.meta.spawn_zones
+        ordered = [zones[key] for key in sorted(zones.keys())]
+        return [zone.position for zone in ordered]
+
+    def _has_min_cut(self, required: int) -> bool:
+        positions = self._spawn_positions()
+        if len(positions) < 2:
+            return True
+        start, goal = positions[0], positions[1]
+        critical = self._critical_points(start, goal)
+        return len(critical) < required - 1
+
+    def _critical_points(
+        self,
+        start: Tuple[int, int],
+        goal: Tuple[int, int],
+    ) -> List[Tuple[int, int]]:
+        reachable = self._flood_fill(start, set())
+        if goal not in reachable:
+            return [start]
+        adjacency = self._build_adjacency(reachable)
+        articulation = self._articulation_points(adjacency, start)
+        critical: List[Tuple[int, int]] = []
+        for point in articulation:
+            if point in (start, goal):
+                continue
+            if self._disconnects(start, goal, point):
+                critical.append(point)
+        return critical
+
+    def _build_adjacency(self, nodes: Set[Tuple[int, int]]) -> dict[Tuple[int, int], List[Tuple[int, int]]]:
+        adjacency: dict[Tuple[int, int], List[Tuple[int, int]]] = {}
+        for node in nodes:
+            neighbours: List[Tuple[int, int]] = []
+            x, y = node
+            for dx, dy in _CARDINALS:
+                nx, ny = x + dx, y + dy
+                if (nx, ny) in nodes:
+                    neighbours.append((nx, ny))
+            adjacency[node] = neighbours
+        return adjacency
+
+    def _articulation_points(
+        self,
+        adjacency: dict[Tuple[int, int], List[Tuple[int, int]]],
+        root: Tuple[int, int],
+    ) -> Set[Tuple[int, int]]:
+        index: dict[Tuple[int, int], int] = {}
+        low: dict[Tuple[int, int], int] = {}
+        parent: dict[Tuple[int, int], Tuple[int, int] | None] = {}
+        articulation: Set[Tuple[int, int]] = set()
+        counter = 0
+
+        def dfs(node: Tuple[int, int]) -> None:
+            nonlocal counter
+            counter += 1
+            index[node] = counter
+            low[node] = counter
+            children = 0
+            for neighbour in adjacency.get(node, []):
+                if neighbour not in index:
+                    parent[neighbour] = node
+                    children += 1
+                    dfs(neighbour)
+                    low[node] = min(low[node], low[neighbour])
+                    if parent.get(node) is None:
+                        if children > 1:
+                            articulation.add(node)
+                    elif low[neighbour] >= index[node]:
+                        articulation.add(node)
+                elif parent.get(node) != neighbour:
+                    low[node] = min(low[node], index[neighbour])
+
+        parent[root] = None
+        dfs(root)
+        return articulation
+
+    def _disconnects(
+        self,
+        start: Tuple[int, int],
+        goal: Tuple[int, int],
+        blocked: Tuple[int, int],
+    ) -> bool:
+        if blocked == start or blocked == goal:
+            return False
+        queue: deque[Tuple[int, int]] = deque([start])
+        visited: Set[Tuple[int, int]] = {start, blocked}
+        while queue:
+            x, y = queue.popleft()
+            if (x, y) == goal:
+                return False
+            for dx, dy in _CARDINALS:
+                nx, ny = x + dx, y + dy
+                coord = (nx, ny)
+                if coord in visited:
+                    continue
+                if not self._is_walkable(nx, ny):
+                    continue
+                visited.add(coord)
+                queue.append(coord)
+        return True
+
+    def _fix_chokepoints(self) -> bool:
+        positions = self._spawn_positions()
+        if len(positions) < 2:
+            return False
+        start, goal = positions[0], positions[1]
+        critical = self._critical_points(start, goal)
+        for point in critical:
+            if self._widen_corridor(point):
+                return True
+        return False
+
+    def _widen_corridor(self, point: Tuple[int, int]) -> bool:
+        x, y = point
+        widened = False
+        for dx, dy in _CARDINALS:
+            nx, ny = x + dx, y + dy
+            if not (0 <= nx < self.width and 0 <= ny < self.height):
+                continue
+            if not self.grid.blocks_move_mask[ny][nx]:
+                continue
+            self._set_floor(nx, ny)
+            widened = True
+        if widened:
+            return True
+        # Fallback: carve perpendicular tiles to create an alternate lane.
+        for dx, dy in _CARDINALS:
+            for px, py in ((x - dy, y + dx), (x + dy, y - dx)):
+                if not (0 <= px < self.width and 0 <= py < self.height):
+                    continue
+                if self.grid.blocks_move_mask[py][px]:
+                    self._set_floor(px, py)
+                    return True
+        return False
+
+
+def ensure_valid_map(
+    spec: MapSpec,
+    *,
+    reassign_spawns: Callable[[MapSpec], MapSpec],
+    max_fixups: int = 3,
+) -> MapSpec:
+    """Validate ``spec`` and attempt fix-ups when necessary."""
+
+    validator = MapValidator(spec)
+    attempts = 0
+    while attempts < max_fixups:
+        result = validator.validate()
+        if result.valid:
+            return validator.spec
+        if not result.fixed:
+            break
+        spec = reassign_spawns(validator.spec)
+        validator = MapValidator(spec)
+        attempts += 1
+    validator = MapValidator(validator.spec)
+    if validator.is_valid():
+        return validator.spec
+    raise RuntimeError("map validation failed after fix-ups")
+
+
+__all__ = ["MapValidator", "ValidationResult", "ensure_valid_map"]

--- a/modules/maps/spec.py
+++ b/modules/maps/spec.py
@@ -9,7 +9,7 @@ from typing import Sequence
 import json
 import logging
 
-from modules.maps.components import MapComponent, MapGrid, MapMeta
+from modules.maps.components import MapComponent, MapGrid, MapMeta, SpawnZone
 from modules.maps.terrain_types import (
     TERRAIN_CATALOG,
     TerrainDescriptor,
@@ -108,6 +108,10 @@ def _cell_to_descriptor(cell: CellSpec) -> TerrainDescriptor:
     return combine(*names)
 
 
+def _clone_spawn_zones(spawn_zones: dict[str, SpawnZone]) -> dict[str, SpawnZone]:
+    return {label: zone.clone() for label, zone in spawn_zones.items()}
+
+
 def to_map_component(spec: MapSpec) -> MapComponent:
     """Instantiate a :class:`MapComponent` from a :class:`MapSpec`."""
 
@@ -117,7 +121,12 @@ def to_map_component(spec: MapSpec) -> MapComponent:
             descriptor = _cell_to_descriptor(spec.cells[y][x])
             grid.set_cell(x, y, descriptor)
 
-    meta = MapMeta(name=spec.meta.name, biome=spec.meta.biome, seed=spec.meta.seed)
+    meta = MapMeta(
+        name=spec.meta.name,
+        biome=spec.meta.biome,
+        seed=spec.meta.seed,
+        spawn_zones=_clone_spawn_zones(spec.meta.spawn_zones),
+    )
     return MapComponent(grid=grid, meta=meta)
 
 
@@ -240,6 +249,7 @@ def from_map_component(
         name=map_component.meta.name,
         biome=map_component.meta.biome,
         seed=map_component.meta.seed,
+        spawn_zones=_clone_spawn_zones(map_component.meta.spawn_zones),
     )
 
     return MapSpec(
@@ -262,6 +272,18 @@ def save_json(spec: MapSpec, path: str | Path) -> None:
             "name": spec.meta.name,
             "biome": spec.meta.biome,
             "seed": spec.meta.seed,
+            "spawn_zones": {
+                label: {
+                    "x": zone.position[0],
+                    "y": zone.position[1],
+                    "width": zone.footprint[0],
+                    "height": zone.footprint[1],
+                    "safe_radius": zone.safe_radius,
+                    "allow_decor": zone.allow_decor,
+                    "allow_hazard": zone.allow_hazard,
+                }
+                for label, zone in spec.meta.spawn_zones.items()
+            },
         },
         "cells": spec.cells,
     }
@@ -282,10 +304,33 @@ def load_json(path: str | Path) -> MapSpec:
         logger.exception("Erreur lors de l'analyse du JSON dans le fichier '%s'", source)
         raise exc.__class__(message, exc.doc, exc.pos) from exc
     meta_data = data.get("meta", {})
+    spawn_data = meta_data.get("spawn_zones", {})
+    spawn_zones: dict[str, SpawnZone] = {}
+    for label, data in spawn_data.items():
+        try:
+            x = int(data["x"])
+            y = int(data["y"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        width = int(data.get("width", 1)) if data.get("width") is not None else 1
+        height = int(data.get("height", 1)) if data.get("height") is not None else 1
+        safe_radius = int(data.get("safe_radius", 1)) if data.get("safe_radius") is not None else 1
+        allow_decor = bool(data.get("allow_decor", False))
+        allow_hazard = bool(data.get("allow_hazard", False))
+        spawn_zones[label] = SpawnZone(
+            label=label,
+            position=(x, y),
+            footprint=(max(1, width), max(1, height)),
+            safe_radius=safe_radius,
+            allow_decor=allow_decor,
+            allow_hazard=allow_hazard,
+        )
+
     meta = MapMeta(
         name=meta_data.get("name", ""),
         biome=meta_data.get("biome", ""),
         seed=meta_data.get("seed"),
+        spawn_zones=spawn_zones,
     )
     cells_data = data.get("cells", [])
     cells: list[list[CellSpec]] = []

--- a/tests/integration/test_map_generation_balance.py
+++ b/tests/integration/test_map_generation_balance.py
@@ -1,0 +1,74 @@
+from core.pathfinding_optimization import OptimizedPathfinding
+from modules.maps.gen.layout import generate_layout
+from modules.maps.gen.params import MapGenParams
+from modules.maps.gen.validate import MapValidator
+from modules.maps.gen.spawns import (
+    _determine_pois,
+    _SpawnTerrain,
+    _fairness_ratio,
+    assign_spawn_zones,
+)
+from modules.maps.spec import MapSpec, to_map_component
+
+
+def _compute_fairness(spec: MapSpec) -> float:
+    component = to_map_component(spec)
+    grid = component.grid
+    terrain = _SpawnTerrain(grid)
+    optimizer = OptimizedPathfinding(terrain)
+    optimizer.min_region_size = max(8, min(grid.width, grid.height) // 2)
+    optimizer.precompute_paths()
+    spawns = list(spec.meta.spawn_zones.values())
+    pois = _determine_pois(grid)
+    return _fairness_ratio(optimizer, spawns, pois)
+
+
+def test_generate_layout_produces_balanced_maps():
+    params_template = dict(
+        size="s",
+        biome="forest",
+        decor_density="mid",
+        cover_ratio=0.2,
+        hazard_ratio=0.1,
+        difficult_ratio=0.1,
+        chokepoint_limit=0.2,
+        room_count=None,
+        corridor_width=(1, 3),
+        symmetry="none",
+    )
+    for seed in range(100):
+        params = MapGenParams(seed=seed, **params_template)
+        spec = generate_layout(params)
+        validator = MapValidator(spec)
+        assert validator.is_valid()
+        fairness = _compute_fairness(spec)
+        assert fairness <= 0.051
+        # Ensure spawn zones are recorded in metadata and not empty.
+        assert spec.meta.spawn_zones
+        for zone in spec.meta.spawn_zones.values():
+            assert isinstance(zone.position, tuple)
+            assert len(zone.position) == 2
+            assert zone.safe_radius >= 0
+
+
+def test_generate_layout_handles_larger_spawn_footprints():
+    params_template = dict(
+        size="s",
+        biome="forest",
+        decor_density="mid",
+        cover_ratio=0.2,
+        hazard_ratio=0.1,
+        difficult_ratio=0.1,
+        chokepoint_limit=0.2,
+        room_count=None,
+        corridor_width=(2, 3),
+        symmetry="none",
+    )
+    for seed in range(10):
+        params = MapGenParams(seed=seed, **params_template)
+        spec = generate_layout(params)
+        spec = assign_spawn_zones(spec, max_spawns=2, footprint=(2, 2))
+        validator = MapValidator(spec)
+        assert validator.is_valid()
+        fairness = _compute_fairness(spec)
+        assert fairness <= 0.051

--- a/tests/unit/test_map_validator.py
+++ b/tests/unit/test_map_validator.py
@@ -1,0 +1,47 @@
+from modules.maps.components import MapMeta
+from modules.maps.gen.spawns import assign_spawn_zones
+from modules.maps.gen.validate import MapValidator, ensure_valid_map
+from modules.maps.spec import MapSpec
+
+
+def _chokepoint_map() -> MapSpec:
+    width, height = 9, 5
+    cells = [["wall" for _ in range(width)] for _ in range(height)]
+    # Carve left room
+    for y in range(1, height - 1):
+        for x in range(1, 3):
+            cells[y][x] = "floor"
+    # Carve right room
+    for y in range(1, height - 1):
+        for x in range(width - 3, width - 1):
+            cells[y][x] = "floor"
+    # Single tile corridor connecting rooms
+    corridor_x = width // 2
+    for y in range(1, height - 1):
+        if y == height // 2:
+            cells[y][corridor_x] = "floor"
+        else:
+            cells[y][corridor_x] = "wall"
+    meta = MapMeta(name="chokepoint", biome="forest", seed=0)
+    return MapSpec(width=width, height=height, cell_size=1, meta=meta, cells=cells)
+
+
+def test_validator_widens_single_chokepoint():
+    spec = _chokepoint_map()
+    assign_spawn_zones(spec, enforce_fairness=False)
+    validator = MapValidator(spec)
+    assert not validator.is_valid()
+    spec = ensure_valid_map(
+        spec,
+        reassign_spawns=lambda current: assign_spawn_zones(current, enforce_fairness=False),
+    )
+    validator = MapValidator(spec)
+    assert validator.is_valid()
+    # Ensure corridor widened: there should be at least two adjacent floor tiles across the choke.
+    mid_y = spec.height // 2
+    corridor_x = spec.width // 2
+    assert spec.cells[mid_y][corridor_x] == "floor"
+    assert (
+        spec.cells[mid_y - 1][corridor_x] == "floor"
+        or spec.cells[mid_y + 1][corridor_x] == "floor"
+    )

--- a/tests/unit/test_spawn_generation.py
+++ b/tests/unit/test_spawn_generation.py
@@ -1,0 +1,71 @@
+from collections import deque
+
+from modules.maps.components import MapMeta
+from core.pathfinding_optimization import OptimizedPathfinding
+from modules.maps.gen.spawns import (
+    assign_spawn_zones,
+    _determine_pois,
+    _fairness_ratio,
+    _SpawnTerrain,
+)
+from modules.maps.spec import MapSpec, to_map_component
+
+
+def _create_open_map(width: int, height: int) -> MapSpec:
+    cells = [["floor" for _ in range(width)] for _ in range(height)]
+    meta = MapMeta(name="arena", biome="forest", seed=0)
+    return MapSpec(width=width, height=height, cell_size=1, meta=meta, cells=cells)
+
+
+def _compute_fairness(spec: MapSpec) -> float:
+    component = to_map_component(spec)
+    grid = component.grid
+    terrain = _SpawnTerrain(grid)
+    optimizer = OptimizedPathfinding(terrain)
+    optimizer.min_region_size = max(8, min(grid.width, grid.height) // 2)
+    optimizer.precompute_paths()
+    spawns = list(spec.meta.spawn_zones.values())
+    pois = _determine_pois(grid)
+    return _fairness_ratio(optimizer, spawns, pois)
+
+
+def _zone_cells(zone, grid):
+    x, y = zone.position
+    width, height = zone.footprint
+    return [
+        (x + dx, y + dy)
+        for dy in range(height)
+        for dx in range(width)
+        if 0 <= x + dx < grid.width and 0 <= y + dy < grid.height
+    ]
+
+
+def test_assign_spawn_zones_produces_fair_safe_spawns():
+    spec = _create_open_map(16, 16)
+    assign_spawn_zones(spec)
+    zones = spec.meta.spawn_zones
+    assert len(zones) >= 2
+    for zone in zones.values():
+        assert zone.safe_radius >= 0
+        assert not zone.allow_hazard
+    fairness = _compute_fairness(spec)
+    assert fairness <= 0.051
+
+
+def test_assign_spawn_zones_supports_larger_footprints():
+    spec = _create_open_map(18, 18)
+    assign_spawn_zones(spec, footprint=(2, 3))
+    zones = spec.meta.spawn_zones
+    assert len(zones) >= 2
+
+    component = to_map_component(spec)
+    grid = component.grid
+    for zone in zones.values():
+        assert zone.footprint == (2, 3)
+        assert zone.safe_radius >= 0
+        for cell in _zone_cells(zone, grid):
+            x, y = cell
+            assert grid.blocks_move_mask[y][x] is False
+            assert grid.hazard_damage[y][x] == 0
+    fairness = _compute_fairness(spec)
+    assert fairness <= 0.051


### PR DESCRIPTION
## Summary
- extend spawn zone metadata and serialization to capture footprint dimensions alongside safety flags
- rework spawn placement safety and fairness logic to operate on configurable footprints and add an optional fairness override
- expand spawn and layout tests to cover larger characters and corridor validations

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68e3791e8e58832db6452d995d2ac854