### PR TITLE
Add Tiled export support and procedural map generation tooling

### DIFF
--- a/modules/maps/events.py
+++ b/modules/maps/events.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from typing import ClassVar, Protocol, runtime_checkable
 
 from modules.maps.components import MapMeta
+from modules.maps.spec import MapSpec
+from modules.maps.gen.params import MapGenParams
 
 
 LOAD_MAP_FROM_TILED = "maps.load_from_tiled"
@@ -12,6 +14,12 @@ LOAD_MAP_FROM_TILED = "maps.load_from_tiled"
 
 MAP_LOADED = "maps.loaded"
 """Event topic emitted when a map entity has been created."""
+
+GENERATE_MAP = "maps.generate"
+"""Event topic requesting a procedural map to be generated."""
+
+MAP_GENERATED = "maps.generated"
+"""Event topic emitted once a procedural :class:`MapSpec` is available."""
 
 
 @runtime_checkable
@@ -51,9 +59,37 @@ class MapLoaded:
         bus.publish(self.topic, map_entity_id=self.map_entity_id, meta=self.meta)
 
 
+@dataclass(frozen=True, slots=True)
+class GenerateMap:
+    """Request procedural map generation using ``params``."""
+
+    params: MapGenParams
+
+    topic: ClassVar[str] = GENERATE_MAP
+
+    def publish(self, bus: _PublishesEvents) -> None:
+        bus.publish(self.topic, params=self.params)
+
+
+@dataclass(frozen=True, slots=True)
+class MapGenerated:
+    """Notification containing the freshly generated :class:`MapSpec`."""
+
+    spec: MapSpec
+
+    topic: ClassVar[str] = MAP_GENERATED
+
+    def publish(self, bus: _PublishesEvents) -> None:
+        bus.publish(self.topic, spec=self.spec)
+
+
 __all__ = [
     "LoadMapFromTiled",
     "MapLoaded",
     "MAP_LOADED",
     "LOAD_MAP_FROM_TILED",
+    "GenerateMap",
+    "MapGenerated",
+    "GENERATE_MAP",
+    "MAP_GENERATED",
 ]

--- a/modules/maps/spec.py
+++ b/modules/maps/spec.py
@@ -96,6 +96,9 @@ class MapSpec:
     def save_json(self, path: str | Path) -> None:
         save_json(self, path)
 
+    def save_tmx(self, path: str | Path) -> None:
+        save_tmx(self, path)
+
     @staticmethod
     def load_json(path: str | Path) -> "MapSpec":
         return load_json(path)
@@ -372,11 +375,20 @@ def load_json(path: str | Path) -> MapSpec:
     )
 
 
+def save_tmx(spec: MapSpec, path: str | Path) -> None:
+    """Serialise a :class:`MapSpec` to a TMX file using the shared schema."""
+
+    from modules.maps.tiled_exporter import export_to_tiled
+
+    export_to_tiled(spec, path)
+
+
 __all__ = [
     "MapSpec",
     "to_map_component",
     "from_map_component",
     "save_json",
     "load_json",
+    "save_tmx",
 ]
 

--- a/modules/maps/systems/map_generator.py
+++ b/modules/maps/systems/map_generator.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from typing import Callable, Protocol
+
+from modules.maps.events import GenerateMap, MapGenerated
+from modules.maps.gen import MapGenParams, decorate, generate_layout, get_rng
+from modules.maps.gen.spawns import assign_spawn_zones
+from modules.maps.gen.validate import ensure_valid_map
+from modules.maps.spec import MapSpec
+
+
+logger = logging.getLogger(__name__)
+
+
+class _EventBus(Protocol):
+    def subscribe(self, event_type: str, callback: Callable[..., None]) -> None:
+        ...
+
+    def publish(self, event_type: str, **payload: object) -> None:
+        ...
+
+
+def generate_map_spec(params: MapGenParams) -> MapSpec:
+    """Run the procedural pipeline and return a validated :class:`MapSpec`."""
+
+    rng = get_rng(params.seed)
+    spec = generate_layout(params)
+    spec = decorate(spec, params, rng)
+    spec = ensure_valid_map(
+        spec,
+        reassign_spawns=lambda current: assign_spawn_zones(current, max_spawns=2),
+        max_fixups=6,
+    )
+    return spec
+
+
+class MapGeneratorSystem:
+    """Listen for :class:`GenerateMap` events and publish :class:`MapGenerated`."""
+
+    def __init__(self, *, event_bus: _EventBus) -> None:
+        self._bus = event_bus
+        self._bus.subscribe(GenerateMap.topic, self._on_generate_requested)
+
+    def _on_generate_requested(self, *, params: MapGenParams, **_: object) -> None:
+        try:
+            spec = generate_map_spec(params)
+        except Exception:
+            logger.exception("Map generation failed for params: size=%s biome=%s seed=%s", params.size, params.biome, params.seed)
+            raise
+        MapGenerated(spec=spec).publish(self._bus)
+
+
+__all__ = ["MapGeneratorSystem", "generate_map_spec"]
+

--- a/modules/maps/systems/map_loader.py
+++ b/modules/maps/systems/map_loader.py
@@ -8,8 +8,8 @@ from typing import Callable, Optional, Protocol
 
 from ecs.components.entity_id import EntityIdComponent
 from modules.maps.components import MapComponent, MapMeta
-from modules.maps.events import LoadMapFromTiled, MapLoaded
-from modules.maps.spec import to_map_component
+from modules.maps.events import LoadMapFromTiled, MapGenerated, MapLoaded
+from modules.maps.spec import MapSpec, to_map_component
 from modules.maps.tiled_importer import TiledImporter
 
 
@@ -50,15 +50,22 @@ class MapLoaderSystem:
         self._active_entity_id: Optional[str] = None
 
         self._bus.subscribe(LoadMapFromTiled.topic, self._on_load_requested)
+        self._bus.subscribe(MapGenerated.topic, self._on_map_generated)
 
     # ------------------------------------------------------------------
     def _on_load_requested(self, *, path: str, **_: object) -> None:
         spec = self._importer.load(path)
+        self._activate_spec(spec, origin_hint=path)
+
+    def _on_map_generated(self, *, spec: MapSpec, **_: object) -> None:
+        self._activate_spec(spec, origin_hint=spec.meta.name)
+
+    def _activate_spec(self, spec: MapSpec, *, origin_hint: str | None) -> None:
         map_component = to_map_component(spec)
 
         self._despawn_active_map()
 
-        entity_id = self._derive_entity_id(spec.meta, path)
+        entity_id = self._derive_entity_id(map_component.meta, origin_hint=origin_hint)
         internal_id = self._ecs.create_entity(
             EntityIdComponent(entity_id),
             map_component,
@@ -75,10 +82,19 @@ class MapLoaderSystem:
         self._active_internal_id = None
         self._active_entity_id = None
 
-    def _derive_entity_id(self, meta: MapMeta, path: str) -> str:
-        base = self._normalise_identifier(meta.name)
-        if not base:
-            base = self._normalise_identifier(Path(path).stem)
+    def _derive_entity_id(self, meta: MapMeta, *, origin_hint: str | None) -> str:
+        candidates = [meta.name]
+        if origin_hint:
+            candidates.append(origin_hint)
+            candidates.append(Path(origin_hint).stem)
+
+        base = ""
+        for candidate in candidates:
+            if not candidate:
+                continue
+            base = self._normalise_identifier(candidate)
+            if base:
+                break
         if not base:
             base = "map"
 
@@ -106,13 +122,13 @@ class MapLoaderSystem:
             1, self.MAX_ENTITY_ID_ATTEMPTS - self.WARNING_THRESHOLD_OFFSET
         )
         if attempts >= warning_threshold:
-            logger.warning(
-                "Map entity id generation for '%s' consumed %s attempts (limit %s); "
-                "consider increasing the limit.",
-                path,
-                attempts,
-                self.MAX_ENTITY_ID_ATTEMPTS,
-            )
+                logger.warning(
+                    "Map entity id generation for '%s' consumed %s attempts (limit %s); "
+                    "consider increasing the limit.",
+                    origin_hint or base,
+                    attempts,
+                    self.MAX_ENTITY_ID_ATTEMPTS,
+                )
         elif attempts:
             if self.INFO_THRESHOLD_DIVISOR <= 0:
                 logger.error("INFO_THRESHOLD_DIVISOR must be positive at runtime.")
@@ -122,14 +138,14 @@ class MapLoaderSystem:
             log(
                 "Map entity id generation for '%s' succeeded after %s attempts "
                 "(limit %s).",
-                path,
+                origin_hint or base,
                 attempts,
                 self.MAX_ENTITY_ID_ATTEMPTS,
             )
         else:
             logger.debug(
                 "Map entity id generation for '%s' succeeded without collisions (limit %s).",
-                path,
+                origin_hint or base,
                 self.MAX_ENTITY_ID_ATTEMPTS,
             )
         return candidate

--- a/modules/maps/tiled_exporter.py
+++ b/modules/maps/tiled_exporter.py
@@ -1,0 +1,299 @@
+"""Helpers to export :class:`MapSpec` instances to Tiled TMX files."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import xml.etree.ElementTree as ET
+
+from modules.maps.spec import CellSpec, MapSpec
+
+
+_COVER_PROPERTY: Mapping[str, str] = {
+    "light_cover": "light",
+    "heavy_cover": "heavy",
+    "fortification": "fortification",
+}
+
+_HAZARD_PROPERTY: Mapping[str, tuple[str, str]] = {
+    "hazard": ("dangerous", "on_enter"),
+    "hazard_severe": ("very_dangerous", "per_tile"),
+}
+
+_BASE_TERRAIN_MOVE_COST: Mapping[str, int] = {
+    "floor": 1,
+    "difficult": 2,
+    "very_difficult": 3,
+}
+
+
+def _normalise_cell(cell: CellSpec) -> list[str]:
+    if isinstance(cell, str):
+        return [cell]
+    return list(cell)
+
+
+def _select_base_descriptor(names: Iterable[str]) -> str | None:
+    name_set = set(names)
+    if "void" in name_set:
+        return None
+    if "wall" in name_set:
+        return "wall"
+    for candidate in ("very_difficult", "difficult", "floor"):
+        if candidate in name_set:
+            return candidate
+    if name_set:
+        return next(iter(name_set))
+    return "floor"
+
+
+def _terrain_properties(descriptor: str) -> Mapping[str, object]:
+    if descriptor == "wall":
+        return {"blocks_move": True, "blocks_los": True, "move_cost": 0}
+    move_cost = _BASE_TERRAIN_MOVE_COST.get(descriptor)
+    if move_cost is None:
+        return {}
+    if move_cost == 1:
+        return {}
+    return {"move_cost": move_cost}
+
+
+def _cover_properties(names: Iterable[str]) -> Mapping[str, object] | None:
+    for descriptor in ("fortification", "heavy_cover", "light_cover"):
+        if descriptor in names:
+            return {"cover": _COVER_PROPERTY[descriptor]}
+    return None
+
+
+def _hazard_properties(names: Iterable[str]) -> Mapping[str, object] | None:
+    for descriptor in ("hazard_severe", "hazard"):
+        if descriptor in names:
+            hazard, timing = _HAZARD_PROPERTY[descriptor]
+            return {"hazard": hazard, "hazard_timing": timing}
+    return None
+
+
+def _collision_properties(names: Iterable[str]) -> Mapping[str, object] | None:
+    if "void" in names:
+        return {"blocks_move": True, "blocks_los": True, "move_cost": 0}
+    if "wall" in names:
+        return {"blocks_move": True, "blocks_los": True, "move_cost": 1}
+    return None
+
+
+def _bool_value(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _prop_attributes(name: str, value: object) -> dict[str, str]:
+    attrs = {"name": name}
+    if isinstance(value, bool):
+        attrs["type"] = "bool"
+        attrs["value"] = _bool_value(value)
+    elif isinstance(value, int):
+        attrs["type"] = "int"
+        attrs["value"] = str(value)
+    else:
+        attrs["value"] = str(value)
+    return attrs
+
+
+@dataclass(slots=True)
+class _Tileset:
+    name: str
+    tilewidth: int
+    tileheight: int
+    tiles: list[dict[str, object]] = field(default_factory=list)
+    _lookup: dict[tuple[tuple[str, object], ...], int] = field(default_factory=dict)
+    firstgid: int | None = None
+
+    def register(self, properties: Mapping[str, object]) -> int:
+        key = tuple(sorted((k, properties[k]) for k in properties))
+        tile_id = self._lookup.get(key)
+        if tile_id is None:
+            tile_id = len(self.tiles)
+            self._lookup[key] = tile_id
+            self.tiles.append(dict(properties))
+        return tile_id
+
+    def gid(self, tile_id: int | None) -> int:
+        if tile_id is None or self.firstgid is None:
+            return 0
+        return self.firstgid + tile_id
+
+    def assign_firstgid(self, next_gid: int) -> int:
+        if not self.tiles:
+            self.firstgid = None
+            return next_gid
+        self.firstgid = next_gid
+        return next_gid + len(self.tiles)
+
+
+def _encode_layer(data: list[list[int]]) -> str:
+    flat: list[str] = []
+    for row in data:
+        flat.extend(str(value) for value in row)
+    return ",".join(flat)
+
+
+def export_to_tiled(spec: MapSpec, out_path: str | Path) -> None:
+    """Write ``spec`` to ``out_path`` using the shared TMX schema."""
+
+    terrain = _Tileset(name="terrain", tilewidth=spec.cell_size, tileheight=spec.cell_size)
+    cover = _Tileset(name="cover", tilewidth=spec.cell_size, tileheight=spec.cell_size)
+    hazard = _Tileset(name="hazard", tilewidth=spec.cell_size, tileheight=spec.cell_size)
+    collision = _Tileset(name="collision", tilewidth=spec.cell_size, tileheight=spec.cell_size)
+
+    width, height = spec.width, spec.height
+    terrain_ids: list[list[int | None]] = [[None for _ in range(width)] for _ in range(height)]
+    cover_ids: list[list[int | None]] = [[None for _ in range(width)] for _ in range(height)]
+    hazard_ids: list[list[int | None]] = [[None for _ in range(width)] for _ in range(height)]
+    collision_ids: list[list[int | None]] = [[None for _ in range(width)] for _ in range(height)]
+
+    for y in range(height):
+        for x in range(width):
+            names = _normalise_cell(spec.cells[y][x])
+            base_descriptor = _select_base_descriptor(names)
+            if base_descriptor is not None:
+                terrain_props = _terrain_properties(base_descriptor)
+                tile_id = terrain.register(terrain_props)
+                terrain_ids[y][x] = tile_id
+            cover_props = _cover_properties(names)
+            if cover_props:
+                cover_ids[y][x] = cover.register(cover_props)
+            hazard_props = _hazard_properties(names)
+            if hazard_props:
+                hazard_ids[y][x] = hazard.register(hazard_props)
+            collision_props = _collision_properties(names)
+            if collision_props:
+                collision_ids[y][x] = collision.register(collision_props)
+
+    tilesets = [terrain, cover, hazard, collision]
+    next_gid = 1
+    for tileset in tilesets:
+        next_gid = tileset.assign_firstgid(next_gid)
+
+    terrain_data = [
+        [terrain.gid(tile_id) for tile_id in row]
+        for row in terrain_ids
+    ]
+    cover_data = [
+        [cover.gid(tile_id) for tile_id in row]
+        for row in cover_ids
+    ]
+    hazard_data = [
+        [hazard.gid(tile_id) for tile_id in row]
+        for row in hazard_ids
+    ]
+    collision_data = [
+        [collision.gid(tile_id) for tile_id in row]
+        for row in collision_ids
+    ]
+
+    map_attrib = {
+        "version": "1.9",
+        "tiledversion": "1.9.2",
+        "orientation": "orthogonal",
+        "renderorder": "right-down",
+        "width": str(width),
+        "height": str(height),
+        "tilewidth": str(spec.cell_size),
+        "tileheight": str(spec.cell_size),
+        "infinite": "0",
+        "nextlayerid": "1",  # placeholder updated below
+        "nextobjectid": "1",
+    }
+    map_elem = ET.Element("map", map_attrib)
+
+    properties_elem = ET.SubElement(map_elem, "properties")
+    ET.SubElement(properties_elem, "property", {"name": "name", "value": spec.meta.name})
+    ET.SubElement(properties_elem, "property", {"name": "biome", "value": spec.meta.biome})
+    seed_value = spec.meta.seed if spec.meta.seed is not None else ""
+    ET.SubElement(
+        properties_elem,
+        "property",
+        {"name": "seed", "value": str(seed_value)},
+    )
+    if spec.meta.spawn_zones:
+        spawn_payload = {
+            label: {
+                "x": zone.position[0],
+                "y": zone.position[1],
+                "width": zone.footprint[0],
+                "height": zone.footprint[1],
+                "safe_radius": zone.safe_radius,
+                "allow_decor": zone.allow_decor,
+                "allow_hazard": zone.allow_hazard,
+            }
+            for label, zone in spec.meta.spawn_zones.items()
+        }
+        ET.SubElement(
+            properties_elem,
+            "property",
+            {
+                "name": "spawn_zones",
+                "type": "string",
+                "value": json.dumps(spawn_payload, separators=(",", ":")),
+            },
+        )
+
+    layer_specs = [
+        ("layer.terrain", terrain_data),
+        ("layer.cover", cover_data),
+        ("layer.hazard", hazard_data),
+        ("layer.collision", collision_data),
+    ]
+
+    map_elem.set("nextlayerid", str(len(layer_specs) + 1))
+
+    for index, (name, data) in enumerate(layer_specs, start=1):
+        layer_elem = ET.SubElement(
+            map_elem,
+            "layer",
+            {
+                "id": str(index),
+                "name": name,
+                "width": str(width),
+                "height": str(height),
+            },
+        )
+        data_elem = ET.SubElement(layer_elem, "data", {"encoding": "csv"})
+        data_elem.text = _encode_layer(data)
+
+    for tileset in tilesets:
+        if not tileset.tiles or tileset.firstgid is None:
+            continue
+        tileset_elem = ET.SubElement(
+            map_elem,
+            "tileset",
+            {
+                "firstgid": str(tileset.firstgid),
+                "name": tileset.name,
+                "tilewidth": str(tileset.tilewidth),
+                "tileheight": str(tileset.tileheight),
+                "tilecount": str(len(tileset.tiles)),
+                "columns": "0",
+            },
+        )
+        ET.SubElement(tileset_elem, "grid", {"orientation": "orthogonal", "width": "1", "height": "1"})
+        for tile_id, props in enumerate(tileset.tiles):
+            tile_elem = ET.SubElement(tileset_elem, "tile", {"id": str(tile_id)})
+            if not props:
+                continue
+            props_elem = ET.SubElement(tile_elem, "properties")
+            for key, value in sorted(props.items()):
+                ET.SubElement(props_elem, "property", _prop_attributes(key, value))
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    tree = ET.ElementTree(map_elem)
+    try:
+        ET.indent(tree, space="  ")  # type: ignore[attr-defined]
+    except AttributeError:  # pragma: no cover - Python < 3.9 fallback
+        pass
+    tree.write(out_path, encoding="utf-8", xml_declaration=True)
+
+
+__all__ = ["export_to_tiled"]
+

--- a/tests/integration/test_tiled_roundtrip.py
+++ b/tests/integration/test_tiled_roundtrip.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.maps.gen import MapGenParams
+from modules.maps.systems.map_generator import generate_map_spec
+from modules.maps.tiled_importer import TiledImporter
+
+
+def _normalise(cell):
+    if isinstance(cell, str):
+        return {cell}
+    return set(cell)
+
+
+def test_exported_tmx_roundtrips_to_mapspec(tmp_path):
+    params = MapGenParams(
+        size="s",
+        biome="forest",
+        decor_density="mid",
+        cover_ratio=0.2,
+        hazard_ratio=0.1,
+        difficult_ratio=0.1,
+        chokepoint_limit=0.2,
+        room_count=None,
+        corridor_width=(1, 3),
+        symmetry="none",
+        seed=42,
+    )
+
+    spec = generate_map_spec(params)
+    spec.meta.name = "roundtrip"
+    spec.meta.biome = params.biome
+
+    tmx_path = Path(tmp_path) / "export.tmx"
+    spec.save_tmx(tmx_path)
+
+    importer = TiledImporter()
+    loaded = importer.load(str(tmx_path))
+
+    assert loaded.width == spec.width
+    assert loaded.height == spec.height
+    assert loaded.cell_size == spec.cell_size
+    assert loaded.meta.name == spec.meta.name
+    assert loaded.meta.biome == spec.meta.biome
+    assert loaded.meta.seed == spec.meta.seed
+    assert set(loaded.meta.spawn_zones) == set(spec.meta.spawn_zones)
+
+    for label, zone in spec.meta.spawn_zones.items():
+        other = loaded.meta.spawn_zones[label]
+        assert other.position == zone.position
+        assert other.footprint == zone.footprint
+        assert other.safe_radius == zone.safe_radius
+        assert other.allow_decor == zone.allow_decor
+        assert other.allow_hazard == zone.allow_hazard
+
+    for y in range(spec.height):
+        for x in range(spec.width):
+            assert _normalise(loaded.cells[y][x]) == _normalise(spec.cells[y][x])
+

--- a/tests/unit/test_map_generator_system.py
+++ b/tests/unit/test_map_generator_system.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from modules.maps.events import GenerateMap, MapGenerated
+from modules.maps.gen import MapGenParams
+from modules.maps.spec import MapSpec
+from modules.maps.systems.map_generator import MapGeneratorSystem
+
+
+class _DummyBus:
+    def __init__(self) -> None:
+        self.subscribers = defaultdict(list)
+        self.published: list[tuple[str, dict[str, object]]] = []
+
+    def subscribe(self, event_type: str, callback) -> None:
+        self.subscribers[event_type].append(callback)
+
+    def publish(self, event_type: str, **payload: object) -> None:
+        self.published.append((event_type, payload))
+        for callback in self.subscribers.get(event_type, []):
+            callback(**payload)
+
+
+def test_map_generator_system_emits_map_generated_event():
+    bus = _DummyBus()
+    MapGeneratorSystem(event_bus=bus)
+
+    params = MapGenParams(
+        size="xs",
+        biome="forest",
+        decor_density="mid",
+        cover_ratio=0.1,
+        hazard_ratio=0.0,
+        difficult_ratio=0.0,
+        chokepoint_limit=0.2,
+        room_count=None,
+        corridor_width=(1, 2),
+        symmetry="none",
+        seed=7,
+    )
+
+    for callback in bus.subscribers[GenerateMap.topic]:
+        callback(params=params)
+
+    generated_events = [payload for event, payload in bus.published if event == MapGenerated.topic]
+    assert generated_events, "Expected a MapGenerated event"
+    spec = generated_events[-1]["spec"]
+    assert isinstance(spec, MapSpec)
+    assert spec.meta.biome == params.biome
+    assert spec.width == MapGenParams.SIZE_DIMENSIONS[params.size][0]
+

--- a/tests/unit/test_map_loader_system.py
+++ b/tests/unit/test_map_loader_system.py
@@ -1,7 +1,8 @@
 from core.event_bus import EventBus
 from ecs.ecs_manager import ECSManager
 from modules.maps.components import MapComponent, MapMeta
-from modules.maps.events import MAP_LOADED, LoadMapFromTiled
+from modules.maps.events import MAP_LOADED, LoadMapFromTiled, MapGenerated
+from modules.maps.spec import MapSpec
 from modules.maps.systems.map_loader import MapLoaderSystem, get_active_map
 
 
@@ -42,3 +43,34 @@ def test_load_map_from_tiled_creates_entity_and_emits_event():
     helper_id, helper_component = get_active_map(ecs_manager)
     assert helper_id == entity_id
     assert helper_component is component
+
+
+def test_map_loader_handles_generated_spec():
+    bus = EventBus()
+    ecs_manager = ECSManager(event_bus=bus)
+    loader = MapLoaderSystem(ecs_manager, event_bus=bus)
+
+    captured: dict[str, object] = {}
+
+    def _on_map_loaded(*, map_entity_id: str, meta: MapMeta, **_: object) -> None:
+        captured["map_entity_id"] = map_entity_id
+        captured["meta"] = meta
+
+    bus.subscribe(MAP_LOADED, _on_map_loaded)
+
+    spec = MapSpec(
+        width=2,
+        height=2,
+        cell_size=1,
+        meta=MapMeta(name="generated", biome="forest"),
+        cells=[["floor", "floor"], ["floor", "floor"]],
+    )
+
+    MapGenerated(spec).publish(bus)
+
+    assert "map_entity_id" in captured
+    entity_id = captured["map_entity_id"]
+    component = ecs_manager.get_component_for_entity(entity_id, MapComponent)
+    assert component is not None
+    active_id, _ = loader.get_active_map()
+    assert active_id == entity_id

--- a/tools/gen_map_cli.py
+++ b/tools/gen_map_cli.py
@@ -1,0 +1,94 @@
+"""Command line interface to generate procedural maps for development."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from modules.maps.gen import MapGenParams
+from modules.maps.systems.map_generator import generate_map_spec
+from modules.maps.spec import save_json, save_tmx
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate a procedural combat map.")
+    parser.add_argument("--size", required=True, choices=sorted(MapGenParams.SIZE_DIMENSIONS.keys()))
+    parser.add_argument(
+        "--biome",
+        required=True,
+        choices=[
+            "building",
+            "forest",
+            "junkyard",
+            "construction",
+            "urban_dense",
+            "urban_sparse",
+        ],
+    )
+    parser.add_argument("--decor-density", default="mid", choices=["low", "mid", "high"])
+    parser.add_argument("--cover-ratio", type=float, default=0.2)
+    parser.add_argument("--hazard-ratio", type=float, default=0.1)
+    parser.add_argument("--difficult-ratio", type=float, default=0.1)
+    parser.add_argument("--chokepoint-limit", type=float, default=0.2)
+    parser.add_argument("--room-count", type=int, default=None)
+    parser.add_argument("--corridor-min", type=int, default=1)
+    parser.add_argument("--corridor-max", type=int, default=3)
+    parser.add_argument("--symmetry", default="none", choices=["none", "mirror_x", "mirror_y", "rot_180"])
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--out", required=True, help="Path to the JSON MapSpec output.")
+    parser.add_argument(
+        "--tmx",
+        help="Optional path to write the Tiled TMX export. When omitted the TMX file is not generated.",
+    )
+    return parser
+
+
+def _validate_ratios(*values: float) -> None:
+    for value in values:
+        if not 0.0 <= value <= 1.0:
+            raise ValueError("probability ratios must lie between 0 and 1")
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        _validate_ratios(
+            args.cover_ratio,
+            args.hazard_ratio,
+            args.difficult_ratio,
+            args.chokepoint_limit,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    corridor_min = max(1, args.corridor_min)
+    corridor_max = max(corridor_min, args.corridor_max)
+
+    params = MapGenParams(
+        size=args.size,
+        biome=args.biome,
+        decor_density=args.decor_density,
+        cover_ratio=args.cover_ratio,
+        hazard_ratio=args.hazard_ratio,
+        difficult_ratio=args.difficult_ratio,
+        chokepoint_limit=args.chokepoint_limit,
+        room_count=args.room_count,
+        corridor_width=(corridor_min, corridor_max),
+        symmetry=args.symmetry,
+        seed=args.seed,
+    )
+
+    spec = generate_map_spec(params)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    save_json(spec, out_path)
+
+    if args.tmx:
+        tmx_path = Path(args.tmx)
+        tmx_path.parent.mkdir(parents=True, exist_ok=True)
+        save_tmx(spec, tmx_path)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a TMX exporter for MapSpec objects and persist spawn zone metadata in Tiled properties
- extend map events and systems to support procedural generation requests and hook MapLoader into generated maps
- provide a CLI for generating maps plus unit/integration tests covering export round-trips and event flow

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3b8e27340832d87cc295d135962b6