### PR TITLE
Refactor action pipeline to use ECS component state

### DIFF
--- a/core/actions/validation.py
+++ b/core/actions/validation.py
@@ -17,6 +17,7 @@ from core.actions.catalog import ACTION_CATALOG, ActionDef
 from core.actions.intent import ActionIntent, CostSpec
 from core.events import topics
 from core.event_bus import Topic
+from ecs.actions.state import get_available_resource
 
 
 RESOURCE_GETTER_PATTERNS = (
@@ -361,6 +362,10 @@ def _resolve_resource(
     ecs: Any,
     rules_ctx: Any,
 ) -> Optional[int]:
+    component_value = get_available_resource(actor_id, resource, ecs)
+    if component_value is not None:
+        return component_value
+
     getter_names = tuple(pattern.format(resource=resource) for pattern in RESOURCE_GETTER_PATTERNS)
     for name in getter_names:
         accessor = getattr(rules_ctx, name, None)

--- a/ecs/actions/state.py
+++ b/ecs/actions/state.py
@@ -1,0 +1,136 @@
+"""Helpers to query ECS-backed action state."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Type, TypeVar
+
+from ecs.components.action_budget import ActionBudgetComponent
+from ecs.components.movement_usage import MovementUsageComponent
+from ecs.components.resource_pool import ResourcePoolComponent
+
+T = TypeVar("T")
+
+
+def _resolve_internal_id(ecs: Any, entity_id: str) -> Optional[int]:
+    """Best-effort resolution of ``entity_id`` to an internal ECS id."""
+
+    if ecs is None:
+        return None
+
+    resolver = getattr(ecs, "resolve_entity", None)
+    if callable(resolver):
+        internal_id = resolver(entity_id)
+        if internal_id is not None:
+            return internal_id
+
+    # Fallback to a public mapping commonly exposed by tests/stubs.
+    entities = getattr(ecs, "entities", None)
+    if isinstance(entities, dict):
+        internal_id = entities.get(entity_id)
+        if isinstance(internal_id, int):
+            return internal_id
+
+    private = getattr(ecs, "_entities", None)
+    if isinstance(private, dict):
+        internal_id = private.get(entity_id)
+        if isinstance(internal_id, int):
+            return internal_id
+
+    return None
+
+
+def _try_get_component(ecs: Any, internal_id: int, component_type: Type[T]) -> Optional[T]:
+    """Return ``component_type`` instance for ``internal_id`` if present."""
+
+    if ecs is None:
+        return None
+
+    getter = getattr(ecs, "try_get_component", None)
+    if callable(getter):
+        return getter(internal_id, component_type)  # type: ignore[return-value]
+
+    alt_getter = getattr(ecs, "get_component", None)
+    if callable(alt_getter):
+        try:
+            component = alt_getter(internal_id, component_type)
+        except KeyError:
+            return None
+        else:
+            if isinstance(component, component_type):
+                return component
+    return None
+
+
+def get_resource_pool(ecs: Any, entity_id: str) -> Optional[ResourcePoolComponent]:
+    """Fetch the :class:`ResourcePoolComponent` for ``entity_id`` if available."""
+
+    internal_id = _resolve_internal_id(ecs, entity_id)
+    if internal_id is None:
+        return None
+    return _try_get_component(ecs, internal_id, ResourcePoolComponent)
+
+
+def get_action_budget(ecs: Any, entity_id: str) -> Optional[ActionBudgetComponent]:
+    """Fetch the :class:`ActionBudgetComponent` for ``entity_id`` if available."""
+
+    internal_id = _resolve_internal_id(ecs, entity_id)
+    if internal_id is None:
+        return None
+    return _try_get_component(ecs, internal_id, ActionBudgetComponent)
+
+
+def get_movement_usage(ecs: Any, entity_id: str) -> Optional[MovementUsageComponent]:
+    """Fetch the :class:`MovementUsageComponent` for ``entity_id`` if available."""
+
+    internal_id = _resolve_internal_id(ecs, entity_id)
+    if internal_id is None:
+        return None
+    return _try_get_component(ecs, internal_id, MovementUsageComponent)
+
+
+def get_available_resource(
+    entity_id: str,
+    resource: str,
+    ecs: Any,
+    *,
+    include_pending: bool = True,
+) -> Optional[int]:
+    """Return currently available ``resource`` for ``entity_id`` from ECS components."""
+
+    resource = str(resource)
+    pool = get_resource_pool(ecs, entity_id)
+    available: Optional[int]
+    if pool is not None:
+        available = pool.get(resource, default=None)
+    else:
+        available = None
+
+    if resource == "movement_points":
+        usage = get_movement_usage(ecs, entity_id)
+        if usage is not None:
+            used = int(getattr(usage, "distance", 0))
+            remaining = (available if available is not None else 0) - used
+            available = remaining
+
+    if include_pending:
+        budget = get_action_budget(ecs, entity_id)
+        if budget is not None:
+            reserved = int(budget.reserved.get(resource, 0))
+            pending = int(budget.pending.get(resource, 0))
+            to_subtract = reserved + pending
+            if to_subtract:
+                base = available if available is not None else 0
+                available = base - to_subtract
+
+    if available is None:
+        return None
+
+    return max(int(available), 0)
+
+
+__all__ = [
+    "get_available_resource",
+    "get_action_budget",
+    "get_movement_usage",
+    "get_resource_pool",
+]

--- a/ecs/components/resource_pool.py
+++ b/ecs/components/resource_pool.py
@@ -1,0 +1,49 @@
+"""ECS component storing resource pools for an entity."""
+
+from __future__ import annotations
+
+from typing import Mapping, MutableMapping
+
+
+class ResourcePoolComponent:
+    """Track consumable resources (action points, ammunition, ...)."""
+
+    def __init__(self, **resources: int) -> None:
+        self._values: MutableMapping[str, int] = {}
+        if resources:
+            self.update(resources)
+
+    def set(self, resource: str, amount: int) -> None:
+        """Assign ``amount`` to ``resource`` in the pool."""
+
+        self._values[str(resource)] = int(amount)
+
+    def add(self, resource: str, amount: int) -> None:
+        """Increase ``resource`` by ``amount`` (may be negative)."""
+
+        key = str(resource)
+        self._values[key] = int(self._values.get(key, 0) + int(amount))
+
+    def get(self, resource: str, default: int | None = 0) -> int | None:
+        """Return the stored value for ``resource`` (defaults to ``default``)."""
+
+        if default is None and resource not in self._values:
+            return None
+        return int(self._values.get(str(resource), default or 0))
+
+    def update(self, mapping: Mapping[str, int]) -> None:
+        """Update the pool from ``mapping`` of resource -> amount."""
+
+        for key, value in mapping.items():
+            self.set(str(key), int(value))
+
+    def as_dict(self) -> dict[str, int]:
+        """Return a plain dictionary copy of the pool values."""
+
+        return {key: int(value) for key, value in self._values.items()}
+
+    def __contains__(self, resource: str) -> bool:  # pragma: no cover - convenience
+        return str(resource) in self._values
+
+
+__all__ = ["ResourcePoolComponent"]

--- a/tests/test_action_selector.py
+++ b/tests/test_action_selector.py
@@ -8,6 +8,8 @@ from typing import Iterable
 import pytest
 
 from core.actions.selector import ActionOption, compute_available_actions
+from ecs.components.resource_pool import ResourcePoolComponent
+from tests.unit.test_utils import StubECS
 
 
 @dataclass
@@ -48,21 +50,25 @@ class DummyRules:
             "vampire": (3, 0),
         }.get(entity_id)
 
-    def get_action_points(self, actor_id: str) -> int:
-        return 3
-
-    def get_ammunition(self, actor_id: str) -> int:
-        return 5
-
     def get_ranged_range(self, actor_id: str) -> int:
         return 6
 
 
-class DummyECS:
+class DummyECS(StubECS):
     def __init__(self) -> None:
+        super().__init__({"hero": 1, "ghoul": 2, "vampire": 3})
         self.positions = {"hero": (0, 0), "ghoul": (0, 1), "vampire": (3, 0)}
-        self.action_points = {"hero": 3}
-        self.ammunition = {"hero": 5}
+
+        internal_id = self.resolve_entity("hero")
+        if internal_id is not None:
+            self.add_component(
+                internal_id,
+                ResourcePoolComponent(
+                    action_points=3,
+                    movement_points=4,
+                    ammunition=5,
+                ),
+            )
 
 
 @pytest.fixture

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -8,17 +8,16 @@ import pytest
 
 from core.actions.intent import ActionIntent, TargetSpec
 from core.actions.validation import validate_intent
+from ecs.components.resource_pool import ResourcePoolComponent
+from tests.unit.test_utils import StubECS
 
 
-@dataclass
-class DummyECS:
-    entities: dict[str, object]
-
-    def resolve_entity(self, entity_id: str):
-        return self.entities.get(entity_id)
+class DummyECS(StubECS):
+    def __init__(self, entities: dict[str, int]) -> None:
+        super().__init__(entities)
 
     def has_entity(self, entity_id: str) -> bool:
-        return entity_id in self.entities
+        return self.resolve_entity(entity_id) is not None
 
 
 class DummyRules:
@@ -58,7 +57,10 @@ class DummyRules:
 
 @pytest.fixture
 def validation_context():
-    ecs = DummyECS({"hero": object(), "ghoul": object()})
+    ecs = DummyECS({"hero": 1, "ghoul": 2})
+    internal_id = ecs.resolve_entity("hero")
+    if internal_id is not None:
+        ecs.add_component(internal_id, ResourcePoolComponent(action_points=1))
     rules = DummyRules()
     rules.set_resource("hero", "action_points", 1)
     return ecs, rules
@@ -97,6 +99,9 @@ def test_validation_rejects_blocked_action(validation_context) -> None:
 def test_validation_checks_resource_cost(validation_context) -> None:
     ecs, rules = validation_context
     rules.set_resource("hero", "action_points", 0)
+    internal_id = ecs.resolve_entity("hero")
+    if internal_id is not None:
+        ecs.add_component(internal_id, ResourcePoolComponent(action_points=0))
 
     intent = ActionIntent(
         actor_id="hero",

--- a/tests/unit/actions/test_validation_pipeline.py
+++ b/tests/unit/actions/test_validation_pipeline.py
@@ -3,6 +3,7 @@ from core.actions.intent import ActionIntent, TargetSpec
 from core.actions.validation import IntentValidator, validate_intent
 from core.events import topics
 
+from ecs.components.resource_pool import ResourcePoolComponent
 from tests.unit.test_utils import DummyEventBus, StubECS, StubRules
 
 from core.actions.validation import _normalize_blocked_actions
@@ -13,6 +14,12 @@ ENTITIES = {"hero": 1, "ghoul": 2}
 
 def test_validate_intent_success() -> None:
     ecs = StubECS(ENTITIES)
+    internal_id = ecs.resolve_entity("hero")
+    if internal_id is not None:
+        ecs.add_component(
+            internal_id,
+            ResourcePoolComponent(action_points=2, movement_points=4),
+        )
     rules = StubRules()
     intent = ActionIntent(
         actor_id="hero",
@@ -29,6 +36,9 @@ def test_validate_intent_success() -> None:
 
 def test_validate_intent_rejects_insufficient_resources() -> None:
     ecs = StubECS(ENTITIES)
+    internal_id = ecs.resolve_entity("hero")
+    if internal_id is not None:
+        ecs.add_component(internal_id, ResourcePoolComponent(action_points=0))
 
     class NoPoints(StubRules):
         def get_action_points(self, actor_id: str) -> int:
@@ -49,6 +59,9 @@ def test_validate_intent_rejects_insufficient_resources() -> None:
 
 def test_validate_intent_rejects_bad_target_kind() -> None:
     ecs = StubECS(ENTITIES)
+    internal_id = ecs.resolve_entity("hero")
+    if internal_id is not None:
+        ecs.add_component(internal_id, ResourcePoolComponent(action_points=1))
     rules = StubRules()
     intent = ActionIntent(
         actor_id="hero",
@@ -64,6 +77,12 @@ def test_validate_intent_rejects_bad_target_kind() -> None:
 
 def test_intent_validator_publishes_events() -> None:
     ecs = StubECS(ENTITIES)
+    internal_id = ecs.resolve_entity("hero")
+    if internal_id is not None:
+        ecs.add_component(
+            internal_id,
+            ResourcePoolComponent(action_points=2, movement_points=4),
+        )
     rules = StubRules()
     validator = IntentValidator(ecs, rules)
     bus = DummyEventBus()


### PR DESCRIPTION
## Summary
- add an ECS ResourcePool component and helper utilities to expose actor budgets through components
- update the selector, validation, and action system to pull resource availability from the ECS helpers
- adapt selector and validation tests to configure ECS-backed resources for actors

## Testing
- pytest -q
- pytest tests/test_action_selector.py tests/unit/actions/test_selector.py tests/unit/actions/test_validation_pipeline.py tests/test_validation.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e621839784832db74157c214cc2f83